### PR TITLE
Used leaf path p.type.id in Querying.ipynb

### DIFF
--- a/examples/notebooks/nexus-demo/04 - Querying.ipynb
+++ b/examples/notebooks/nexus-demo/04 - Querying.ipynb
@@ -481,7 +481,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resources = forge.search(p.type == \"Person\", limit=5)"
+    "resources = forge.search(p.type.id == \"Person\", limit=5)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #26 
p.type is a composed path containing p.type.id. p.type.id should be used for filtering.