### PR TITLE
Fixed atlas section in notebook to use correct forge session

### DIFF
--- a/examples/notebooks/use-cases/BBP KG Search and Download.ipynb
+++ b/examples/notebooks/use-cases/BBP KG Search and Download.ipynb
@@ -625,9 +625,9 @@
    "outputs": [],
    "source": [
     "DISPLAY_LIMIT = 10\n",
-    "reshaped_data = forge_atlas.reshape(data, keep=[\"id\",\"name\",\"subject\",\"brainLocation.brainRegion.id\",\"brainLocation.brainRegion.label\",\"brainLocation.layer.id\",\"brainLocation.layer.label\", \"contribution\",\"brainLocation.layer.id\",\"brainLocation.layer.label\",\"distribution.name\",\"distribution.contentUrl\",\"distribution.encodingFormat\"])\n",
+    "reshaped_data = forge_atlas.reshape(data, keep=[\"id\",\"name\",\"brainLocation.brainRegion.id\",\"brainLocation.brainRegion.label\", \"contribution\",\"distribution.name\",\"distribution.contentUrl\",\"distribution.encodingFormat\"])\n",
     "\n",
-    "forge.as_dataframe(reshaped_data[:DISPLAY_LIMIT])"
+    "forge_atlas.as_dataframe(reshaped_data[:DISPLAY_LIMIT])"
    ]
   },
   {
@@ -637,7 +637,7 @@
    "outputs": [],
    "source": [
     "dirpath = \"./downloaded/\"\n",
-    "forge.download(data, \"distribution.contentUrl\", dirpath)"
+    "forge_atlas.download(data, \"distribution.contentUrl\", dirpath)"
    ]
   }
  ],


### PR DESCRIPTION
Atlas section in BBP KG Search and Download.ipynb notebook was not using the forge_atlas session consistently.
Addresses issues raised in #36.