### PR TITLE
Consider Dataset files as parts

### DIFF
--- a/examples/notebooks/getting-started/02 - Datasets.ipynb
+++ b/examples/notebooks/getting-started/02 - Datasets.ipynb
@@ -119,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(persons)"
@@ -178,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "associations.download(\"files\", \"./downloaded/\")"
+    "associations.download(\"parts\", \"./downloaded/\")"
    ]
   },
   {

--- a/kgforge/specializations/resources/datasets.py
+++ b/kgforge/specializations/resources/datasets.py
@@ -88,7 +88,8 @@ class Dataset(Resource):
         # path: DirPath.
         """Add (different) files as parts of the dataset."""
         action = self._forge.attach(path, content_type)
-        _set(self, "hasPart", action)
+        distribution = Resource(distribution=action)
+        _set(self, "hasPart", distribution)
 
     @catch
     def download(self, source: str, path: str) -> None:
@@ -96,8 +97,6 @@ class Dataset(Resource):
         """Download the distributions of the dataset or the files part of the dataset."""
         if source == "distributions":
             follow = "distribution.contentUrl"
-        elif source == "files":
-            follow = "hasPart.contentUrl"
         elif source == "parts":
             follow = "hasPart.distribution.contentUrl"
         else:


### PR DESCRIPTION
Change of behaviour for `Dataset.add_files(...)`.

The **current** behaviour produces the following structure.
```
{
  ...
  "hasPart": [
    {
      "@type": "DataDownload",
      ...
    },
    ...
  ]
}
```

The **new** behaviour produces the following structure.
This introduces the new level `distribution`.
```
{
  ...
  "hasPart": [
    {
      "distribution": {
         "@type": "DataDownload",
         ...
      }
    },
    ...
  ]
}
```