### PR TITLE
Prevent Store.download() to overwrite existing files

### DIFF
--- a/docs/source/archetypes.rst
+++ b/docs/source/archetypes.rst
@@ -59,7 +59,7 @@ The Store provides the interface of storage for different technologies to be imp
      register(data: Union[Resource, List[Resource]]) -> None
      upload(path: str) -> Union[Resource, List[Resource]]
      retrieve(id: str, version: Optional[Union[int, str]]) -> Resource
-     download(data: Union[Resource, List[Resource]], follow: str, path: str) -> None
+     download(data: Union[Resource, List[Resource]], follow: str, path: str, overwrite: bool) -> None
      update(data: Union[Resource, List[Resource]]) -> None
      tag(data: Union[Resource, List[Resource]], value: str) -> None
      deprecate(data: Union[Resource, List[Resource]]) -> None

--- a/docs/source/interaction.rst
+++ b/docs/source/interaction.rst
@@ -184,7 +184,7 @@ extracted properties, such as  content type, size, file name, etc.
      add_derivation(resource: Resource, versioned: bool = True, **kwargs) -> None
      add_invalidation(**kwargs) -> None
      add_files(path: str, content_type: str = None) -> None
-     download(source: str, path: str) -> None
+     download(source: str, path: str, overwrite: bool = False) -> None
 
 Storing
 -------
@@ -214,7 +214,7 @@ the properties and a specific value and (3) using a simplified version of SPARQL
    paths(type: str) -> PathsWrapper
    search(*filters, **params) -> List[Resource]
    sparql(query: str) -> List[Resource]
-   download(data: Union[Resource, List[Resource]], follow: str, path: str) -> None
+   download(data: Union[Resource, List[Resource]], follow: str, path: str, overwrite: bool = False) -> None
 
 Versioning
 ----------

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -132,7 +132,8 @@ class Store(ABC):
         # TODO This operation might be adapted if other file metadata are needed.
         not_supported()
 
-    def download(self, data: Union[Resource, List[Resource]], follow: str, path: str) -> None:
+    def download(self, data: Union[Resource, List[Resource]], follow: str, path: str,
+                 overwrite: bool) -> None:
         # path: DirPath.
         urls = collect_values(data, follow, DownloadingError)
         count = len(urls)
@@ -145,7 +146,10 @@ class Store(ABC):
         for x in urls:
             filename = self._retrieve_filename(x)
             filepath = dirpath / filename
-            filepaths.append(f"{filepath}.{timestamp}" if filepath.exists() else str(filepath))
+            if not overwrite and filepath.exists():
+                filepaths.append(f"{filepath}.{timestamp}")
+            else:
+                filepaths.append(str(filepath))
         if count > 1:
             self._download_many(urls, filepaths)
         else:

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -135,6 +135,9 @@ class Store(ABC):
     def download(self, data: Union[Resource, List[Resource]], follow: str, path: str) -> None:
         # path: DirPath.
         urls = collect_values(data, follow, DownloadingError)
+        count = len(urls)
+        if count == 0:
+            raise DownloadingError("no URLs were found")
         dirpath = Path(path)
         dirpath.mkdir(parents=True, exist_ok=True)
         timestamp = time.strftime("%Y%m%d%H%M%S")
@@ -142,14 +145,8 @@ class Store(ABC):
         for x in urls:
             filename = self._retrieve_filename(x)
             filepath = dirpath / filename
-            if filepath.exists():
-                filepaths.append(f"{filepath}.{timestamp}")
-            else:
-                filepaths.append(str(filepath))
-        size = len(filepaths)
-        if size < 1:
-            raise DownloadingError("no URLs were found")
-        elif size > 1:
+            filepaths.append(f"{filepath}.{timestamp}" if filepath.exists() else str(filepath))
+        if count > 1:
             self._download_many(urls, filepaths)
         else:
             self._download_one(urls[0], filepaths[0])

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -137,15 +137,15 @@ class Store(ABC):
         urls = collect_values(data, follow, DownloadingError)
         dirpath = Path(path)
         dirpath.mkdir(parents=True, exist_ok=True)
+        timestamp = time.strftime("%Y%m%d%H%M%S")
         filepaths = []
         for x in urls:
             filename = self._retrieve_filename(x)
             filepath = dirpath / filename
             if filepath.exists():
-                timestamp = time.strftime("%Y%m%d%H%M%S")
-                filepaths.append(Path(f"{filepath}.{timestamp}"))
+                filepaths.append(f"{filepath}.{timestamp}")
             else:
-                filepaths.append(filepath)
+                filepaths.append(str(filepath))
         size = len(filepaths)
         if size < 1:
             raise DownloadingError("no URLs were found")
@@ -154,14 +154,14 @@ class Store(ABC):
         else:
             self._download_one(urls[0], filepaths[0])
 
-    def _download_many(self, urls: List[str], paths: List[Path]) -> None:
+    def _download_many(self, urls: List[str], paths: List[str]) -> None:
         # paths: List[FilePath].
         # Bulk downloading could be optimized by overriding this method in the specialization.
         # POLICY Should follow self._download_one() policies.
         for url, path in zip(urls, paths):
             self._download_one(url, path)
 
-    def _download_one(self, url: str, path: Path) -> None:
+    def _download_one(self, url: str, path: str) -> None:
         # path: FilePath.
         # POLICY Should notify of failures with exception DownloadingError including a message.
         not_supported()

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -13,6 +13,7 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 import re
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Match, Optional, Union
@@ -127,28 +128,41 @@ class Store(ABC):
         # TODO These two operations might be abstracted here when other stores will be implemented.
         pass
 
+    def _retrieve_filename(self, id: str) -> str:
+        # TODO This operation might be adapted if other file metadata are needed.
+        not_supported()
+
     def download(self, data: Union[Resource, List[Resource]], follow: str, path: str) -> None:
         # path: DirPath.
         urls = collect_values(data, follow, DownloadingError)
-        size = len(urls)
-        p = Path(path)
-        p.mkdir(parents=True, exist_ok=True)
+        dirpath = Path(path)
+        dirpath.mkdir(parents=True, exist_ok=True)
+        filepaths = []
+        for x in urls:
+            filename = self._retrieve_filename(x)
+            filepath = dirpath / filename
+            if filepath.exists():
+                timestamp = time.strftime("%Y%m%d%H%M%S")
+                filepaths.append(Path(f"{filepath}.{timestamp}"))
+            else:
+                filepaths.append(filepath)
+        size = len(filepaths)
         if size < 1:
             raise DownloadingError("no URLs were found")
         elif size > 1:
-            self._download_many(urls, p)
+            self._download_many(urls, filepaths)
         else:
-            self._download_one(urls[0], p)
+            self._download_one(urls[0], filepaths[0])
 
-    def _download_many(self, urls: List[str], path: Path) -> None:
-        # path: DirPath.
+    def _download_many(self, urls: List[str], paths: List[Path]) -> None:
+        # paths: List[FilePath].
         # Bulk downloading could be optimized by overriding this method in the specialization.
         # POLICY Should follow self._download_one() policies.
-        for x in urls:
-            self._download_one(x, path)
+        for url, path in zip(urls, paths):
+            self._download_one(url, path)
 
     def _download_one(self, url: str, path: Path) -> None:
-        # path: DirPath.
+        # path: FilePath.
         # POLICY Should notify of failures with exception DownloadingError including a message.
         not_supported()
 

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -323,9 +323,10 @@ class KnowledgeGraphForge:
         return self._store.sparql(query, debug, limit, offset)
 
     @catch
-    def download(self, data: Union[Resource, List[Resource]], follow: str, path: str) -> None:
+    def download(self, data: Union[Resource, List[Resource]], follow: str, path: str,
+                 overwrite: bool = False) -> None:
         # path: DirPath.
-        self._store.download(data, follow, path)
+        self._store.download(data, follow, path, overwrite)
 
     # Storing User Interface.
 

--- a/kgforge/specializations/resources/datasets.py
+++ b/kgforge/specializations/resources/datasets.py
@@ -92,7 +92,7 @@ class Dataset(Resource):
         _set(self, "hasPart", distribution)
 
     @catch
-    def download(self, source: str, path: str) -> None:
+    def download(self, source: str, path: str, overwrite: bool = False) -> None:
         # path: DirPath.
         """Download the distributions of the dataset or the files part of the dataset."""
         if source == "distributions":
@@ -101,7 +101,7 @@ class Dataset(Resource):
             follow = "hasPart.distribution.contentUrl"
         else:
             raise ValueError("unrecognized source")
-        self._forge.download(self, follow, path)
+        self._forge.download(self, follow, path, overwrite)
 
 
 def _set(dataset: Dataset, attr: str, data: Union[Resource, List[Resource], LazyAction]) -> None:

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -169,6 +169,15 @@ class BlueBrainNexus(Store):
             self.service.sync_metadata(resource, response)
             return resource
 
+    def _retrieve_filename(self, id: str) -> str:
+        try:
+            response = requests.get(id, headers=self.service.headers)
+            response.raise_for_status()
+            metadata = response.json()
+            return metadata["_filename"]
+        except HTTPError as e:
+            raise DownloadingError(_error_message(e))
+
     def _download_one(self, url: str, path: Path) -> None:
         try:
             # this is a hack since _self and _id have the same uuid

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -178,7 +178,7 @@ class BlueBrainNexus(Store):
         except HTTPError as e:
             raise DownloadingError(_error_message(e))
 
-    def _download_one(self, url: str, path: Path) -> None:
+    def _download_one(self, url: str, path: str) -> None:
         try:
             # this is a hack since _self and _id have the same uuid
             file_id = url.split("/")[-1]
@@ -187,7 +187,7 @@ class BlueBrainNexus(Store):
             if len(file_id) < 1:
                 raise DownloadingError("Invalid file name")
             nexus.files.fetch(org_label=self.organisation, project_label=self.project,
-                              file_id=file_id, out_filepath=str(path))
+                              file_id=file_id, out_filepath=path)
         except HTTPError as e:
             raise DownloadingError(_error_message(e))
 


### PR DESCRIPTION
Improvements when using `forge.download(...)` and `Dataset.download(...)`:
- If the given directory path doesn't exist and no URLs were found, the path is not created.
- When a file with the same file name is already existing, it is not overwritten.
The concerned downloaded file has a timestamp added as suffix.
Here is an example:
![store-download-no_overwriting](https://user-images.githubusercontent.com/4543376/87657286-eae3c080-c75a-11ea-9971-4a19e6387d87.png)
