### PR TITLE
Add cross-bucket retrieval feature

### DIFF
--- a/docs/source/archetypes.rst
+++ b/docs/source/archetypes.rst
@@ -58,7 +58,7 @@ The Store provides the interface of storage for different technologies to be imp
    Store(endpoint: Optional[str] = None, bucket: Optional[str] = None, token: Optional[str] = None, versioned_id_template: Optional[str] = None, file_resource_mapping: Optional[str] = None))
      register(data: Union[Resource, List[Resource]]) -> None
      upload(path: str) -> Union[Resource, List[Resource]]
-     retrieve(id: str, version: Optional[Union[int, str]]) -> Resource
+     retrieve(id: str, version: Optional[Union[int, str]], cross_bucket: bool) -> Resource
      download(data: Union[Resource, List[Resource]], follow: str, path: str) -> None
      update(data: Union[Resource, List[Resource]]) -> None
      tag(data: Union[Resource, List[Resource]], value: str) -> None

--- a/docs/source/interaction.rst
+++ b/docs/source/interaction.rst
@@ -210,7 +210,7 @@ the properties and a specific value and (3) using a simplified version of SPARQL
 
 .. code-block:: python
 
-   retrieve(id: str, version: Optional[Union[int, str]] = None) -> Resource
+   retrieve(id: str, version: Optional[Union[int, str]] = None, cross_bucket: bool = False) -> Resource
    paths(type: str) -> PathsWrapper
    search(*filters, **params) -> List[Resource]
    sparql(query: str) -> List[Resource]

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -120,7 +120,8 @@ class Store(ABC):
     # C[R]UD.
 
     @abstractmethod
-    def retrieve(self, id: str, version: Optional[Union[int, str]]) -> Resource:
+    def retrieve(self, id: str, version: Optional[Union[int, str]], cross_bucket: bool
+                 ) -> Resource:
         # POLICY Should notify of failures with exception RetrievalError including a message.
         # POLICY Resource _store_metadata should be set using wrappers.dict.wrap_dict().
         # POLICY Resource _synchronized should be set to True.

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -304,8 +304,9 @@ class KnowledgeGraphForge:
     # Querying User Interface.
 
     @catch
-    def retrieve(self, id: str, version: Optional[Union[int, str]] = None) -> Resource:
-        return self._store.retrieve(id, version)
+    def retrieve(self, id: str, version: Optional[Union[int, str]] = None,
+                 cross_bucket: bool = False) -> Resource:
+        return self._store.retrieve(id, version, cross_bucket)
 
     @catch
     def paths(self, type: str) -> PathsWrapper:

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -147,26 +147,29 @@ class BlueBrainNexus(Store):
 
     # C[R]UD.
 
-    def retrieve(self, id: str, version: Optional[Union[int, str]] = None) -> Resource:
-        try:
+    def retrieve(self, id: str, version: Optional[Union[int, str]],
+                 cross_bucket: bool) -> Resource:
+        segment = "resolvers" if cross_bucket else "resources"
+        url = f"{self.endpoint}/{segment}/{self.bucket}/_/{quote_plus(id)}"
+        if version is not None:
             if isinstance(version, int):
-                response = nexus.resources.fetch(org_label=self.organisation,
-                                                 project_label=self.project,
-                                                 resource_id=id, rev=version)
+                params = {"rev": version}
             elif isinstance(version, str):
-                response = nexus.resources.fetch(org_label=self.organisation,
-                                                 project_label=self.project,
-                                                 resource_id=id, tag=version)
+                params = {"tag": version}
             else:
-                response = nexus.resources.fetch(org_label=self.organisation,
-                                                 project_label=self.project,
-                                                 resource_id=id)
+                raise RetrievalError("incorrect 'version'")
+        else:
+            params = None
+        try:
+            response = requests.get(url, params=params, headers=self.service.headers)
+            response.raise_for_status()
         except HTTPError as e:
             raise RetrievalError(_error_message(e))
         else:
-            resource = self.service.to_resource(response)
+            data = response.json()
+            resource = self.service.to_resource(data)
             resource._synchronized = True
-            self.service.sync_metadata(resource, response)
+            self.service.sync_metadata(resource, data)
             return resource
 
     def _download_one(self, url: str, path: Path) -> None:

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -21,6 +21,7 @@ from kgforge.core.archetypes import Resolver, Store
 from kgforge.core.commons.context import Context
 from kgforge.core.commons.exceptions import (DeprecationError, RegistrationError,
                                              RetrievalError, TaggingError, UpdatingError)
+from kgforge.core.commons.execution import not_supported
 from kgforge.core.conversions.json import as_json, from_json
 from kgforge.core.wrappings.dict import wrap_dict
 
@@ -50,7 +51,10 @@ class DemoStore(Store):
 
     # C[R]UD.
 
-    def retrieve(self, id: str, version: Optional[Union[int, str]]) -> Resource:
+    def retrieve(self, id: str, version: Optional[Union[int, str]],
+                 cross_bucket: bool) -> Resource:
+        if cross_bucket:
+            not_supported(("cross_bucket", True))
         try:
             record = self.service.read(id, version)
         except StoreLibrary.RecordMissing:


### PR DESCRIPTION
### Usage

```
resource = forge.retrieve(<resource_id>, cross_bucket=True)
```

### Behaviour

When using `cross_bucket=True`, resources could be retrieved from other buckets.

### Example for Nexus Delta v1.3

If the configured `Store` bucket has the following Nexus Delta resolvers:

- an InProject resolver with priority 1,
- a CrossProject resolver to schemas and JSON-LD context with priority 2,
- a CrossProject resolver to other buckets with priority 3,

then, using `cross_bucket=True` will try to retrieve the resource with the given `@id`:

- firstly in the configured `Store` bucket,
- secondly amongst the schemas and JSON-LD context,
- thirdly in the other buckets.