### PR TITLE
Fix releasing on PyPI by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,11 @@ script:
 after_success:
   - codecov
 
-branches:
-  only:
-    - master
-
 deploy:
   provider: pypi
   on:
     tags: true
-    branch: master
+    all_branches: true
     condition: "$TRAVIS_PYTHON_VERSION == 3.6"
   user: bbp.opensource
   password:


### PR DESCRIPTION
Attempt to fix the issue with Travis saying:

> Skipping a deployment with the pypi provider because this is not a tagged commit.

while the commit 906532b was tagged with `git tag -a v0.3.1 HEAD`.