### PR TITLE
Bugfix on nested_asyncio

### DIFF
--- a/kgforge/specializations/stores/nexus/service.py
+++ b/kgforge/specializations/stores/nexus/service.py
@@ -93,7 +93,7 @@ class Service:
         sparql_view = searchendpoints['sparql']['endpoint'] if searchendpoints and "sparql" in searchendpoints else "nxv:defaultSparqlIndex"
 
         self.sparql_endpoint = "/".join((self.endpoint, "views", quote_plus(org), quote_plus(prj),quote_plus(sparql_view), "sparql"))
-        # This async to work on jupyter notebooks
+        # The following code is for async to work on jupyter notebooks
         try:
             asyncio.get_event_loop()
             nest_asyncio.apply()

--- a/kgforge/specializations/stores/nexus/service.py
+++ b/kgforge/specializations/stores/nexus/service.py
@@ -90,7 +90,11 @@ class Service:
         self.sparql_endpoint = "/".join((endpoint, "views", quote_plus(org), quote_plus(prj),
                                     "nxv:defaultSparqlIndex", "sparql"))
         # This async to work on jupyter notebooks
-        nest_asyncio.apply()
+        try:
+            asyncio.get_event_loop()
+            nest_asyncio.apply()
+        except RuntimeError:
+            pass
 
     def get_project_context(self) -> Dict:
         project_data = nexus.projects.fetch(self.organisation, self.project)


### PR DESCRIPTION
Hi,

I fixed the bug that appears from nesting event loops, when the current event loop does not exist. I am not sure it's the best solution, but now works for both Jupyter notebook and on the server side.

`asyncio.get_event_loop()` retrieves the current event loop and if it does not exists throws a `RuntimeError`, this corresponds to the case when we run the forge on the server-side.

