### PR TITLE
Added query param support when retrieving a resource

### DIFF
--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -214,7 +214,6 @@ class BlueBrainNexus(Store):
             resource = self.service.to_resource(data)
             resource._synchronized = True
             self.service.sync_metadata(resource, data)
-
             return resource
 
     def _retrieve_filename(self, id: str) -> str:

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -20,7 +20,7 @@ from asyncio import Semaphore, Task
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
-from urllib.parse import quote_plus, unquote
+from urllib.parse import quote_plus, unquote, urlparse, parse_qs
 
 import nexussdk as nexus
 import requests
@@ -185,8 +185,11 @@ class BlueBrainNexus(Store):
 
     def retrieve(self, id: str, version: Optional[Union[int, str]],
                  cross_bucket: bool) -> Resource:
+
         segment = "resolvers" if cross_bucket else "resources"
-        url = f"{self.endpoint}/{segment}/{self.bucket}/_/{quote_plus(id)}"
+        parsed_id = urlparse(id)
+        id_without_query = f"{parsed_id.scheme}://{parsed_id.netloc}{parsed_id.path}"
+        params = None
         if version is not None:
             if isinstance(version, int):
                 params = {"rev": version}
@@ -194,8 +197,13 @@ class BlueBrainNexus(Store):
                 params = {"tag": version}
             else:
                 raise RetrievalError("incorrect 'version'")
-        else:
-            params = None
+        if parsed_id.query is not None:
+            query_params = parse_qs(parsed_id.query)
+            if params is not None:
+                query_params.update(params)
+            params = query_params
+
+        url = f"{self.endpoint}/{segment}/{self.bucket}/_/{quote_plus(id_without_query)}"
         try:
             response = requests.get(url, params=params, headers=self.service.headers)
             response.raise_for_status()
@@ -206,6 +214,7 @@ class BlueBrainNexus(Store):
             resource = self.service.to_resource(data)
             resource._synchronized = True
             self.service.sync_metadata(resource, data)
+
             return resource
 
     def _retrieve_filename(self, id: str) -> str:


### PR DESCRIPTION
Currently calling:

`forge.retrieve(id=https://..?rev=1)` will throw a RetrievalError with a 404 when using a configured Nexus Delta Store.

Also the query params (e.g rev=1) were not taken into account. The solution is to extract the query params out of the url and add them as values of the params argument in `requests.get(url, params=...)`. 

When the `version` argument is set (like in `forge.retrieve(id=https://..?rev=1&p=aparam, version=2)` ), then it should superseed the `rev` query param while the other query params (e.g `p=aparam`) should be kept as is.

