### PR TITLE
Fixed failing forge.download

### DIFF
--- a/examples/notebooks/getting-started/02 - Datasets.ipynb
+++ b/examples/notebooks/getting-started/02 - Datasets.ipynb
@@ -180,7 +180,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "associations.download(\"parts\", \"./downloaded/\")"
+    "associations.download(path=\"./downloaded/\", source=\"parts\")"
    ]
   },
   {
@@ -306,7 +306,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.download(\"parts\", \"./downloaded/\")"
+    "dataset.download(path=\"./downloaded/\", source=\"parts\")"
    ]
   },
   {

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -140,7 +140,7 @@ class Store(ABC):
         urls = collect_values(data, follow, DownloadingError)
         count = len(urls)
         if count == 0:
-            raise DownloadingError(f"path to follow '{follow}' were not found in any provided resource.")
+            raise DownloadingError(f"path to follow '{follow}' was not found in any provided resource.")
         dirpath = Path(path)
         dirpath.mkdir(parents=True, exist_ok=True)
         timestamp = time.strftime("%Y%m%d%H%M%S")

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -140,7 +140,7 @@ class Store(ABC):
         urls = collect_values(data, follow, DownloadingError)
         count = len(urls)
         if count == 0:
-            raise DownloadingError("no URLs were found")
+            raise DownloadingError(f"path to follow '{follow}' were not found in any provided resource.")
         dirpath = Path(path)
         dirpath.mkdir(parents=True, exist_ok=True)
         timestamp = time.strftime("%Y%m%d%H%M%S")

--- a/kgforge/specializations/resources/datasets.py
+++ b/kgforge/specializations/resources/datasets.py
@@ -92,7 +92,7 @@ class Dataset(Resource):
         _set(self, "hasPart", distribution)
 
     @catch
-    def download(self, source: str, path: str, overwrite: bool = False) -> None:
+    def download(self, path: str, source: str = "distributions", overwrite: bool = False) -> None:
         # path: DirPath.
         """Download the distributions of the dataset or the files part of the dataset."""
         if source == "distributions":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,3 +281,64 @@ def building_jsonld(metadata_context, metadata_data_compacted, metadata_data_exp
         elif form is Form.EXPANDED.value:
             return _make_jsonld_expanded(rsrc, store_metadata, context)
     return _make_jsonld
+
+
+
+SCOPE = "terms"
+MODEL = "DemoModel"
+STORE = "DemoStore"
+RESOLVER = "DemoResolver"
+
+
+@pytest.fixture(params=[
+    MODEL,
+    f"{MODEL} from kgforge.specializations.models",
+    f"{MODEL} from kgforge.specializations.models.demo_model"])
+def model(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    STORE,
+    f"{STORE} from kgforge.specializations.stores",
+    f"{STORE} from kgforge.specializations.stores.demo_store"])
+def store(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    RESOLVER,
+    f"{RESOLVER} from kgforge.specializations.resolvers",
+    f"{RESOLVER} from kgforge.specializations.resolvers.demo_resolver"])
+def resolver(request):
+    return request.param
+
+
+@pytest.fixture
+def config(model, store, resolver):
+    return {
+        "Model": {
+            "name": model,
+            "origin": "directory",
+            "source": "tests/data/demo-model/",
+        },
+        "Store": {
+            "name": store,
+        },
+        "Resolvers": {
+            SCOPE: [
+                {
+                    "resolver": resolver,
+                    "origin": "directory",
+                    "source": "tests/data/demo-resolver/",
+                    "targets": [
+                        {
+                            "identifier": "sex",
+                            "bucket": "sex.json",
+                        },
+                    ],
+                    "result_resource_mapping": "../../configurations/demo-resolver/term-to-resource-mapping.hjson",
+                },
+            ],
+        },
+    }

--- a/tests/core/archetypes/test_store.py
+++ b/tests/core/archetypes/test_store.py
@@ -15,8 +15,9 @@
 # Placeholder for the test suite for actions.
 import pytest
 
+from kgforge.core import Resource, KnowledgeGraphForge
 from kgforge.core.archetypes.store import rewrite_sparql
-
+from kgforge.core.commons.exceptions import DownloadingError
 
 context = {
     "@context": {
@@ -67,3 +68,10 @@ form_store_metadata_combinations = [
 def test_rewrite_sparql(query, expected):
     result = rewrite_sparql(query, context, prefixes)
     assert result == expected
+
+
+def test_download(config):
+    simple = Resource(type="Experiment", url="file.gz")
+    with pytest.raises(DownloadingError):
+        forge = KnowledgeGraphForge(config)
+        forge._store.download(simple, "fake.path", "./", overwrite=False)

--- a/tests/core/test_reshaping.py
+++ b/tests/core/test_reshaping.py
@@ -39,4 +39,4 @@ def test_collect_values():
     r = collect_values(data_set, "fake.path")
     assert len(r) == 0
     with pytest.raises(ValueError):
-        r = collect_values(None, "hasPart.url",ValueError)
+        collect_values(None, "hasPart.url",ValueError)

--- a/tests/core/test_reshaping.py
+++ b/tests/core/test_reshaping.py
@@ -26,10 +26,17 @@ def test_collect_values():
     r = collect_values(deep, "level1.level2.url")
     assert deep.level1.level2.url in r, "url should be in the list"
     files = [Resource(type="Experiment", url=f"file{i}") for i in range(3)]
+    files.append(Resource(type="Experiment", contentUrl=f"file3"))
     r = collect_values(files, "url")
     assert ["file0", "file1", "file2"] == r, "three elements should be in the list"
+    r = collect_values(files, "contentUrl")
+    assert ["file3"] == r, "one element should be in the list"
     data_set = Resource(type="Dataset", hasPart=files)
+    r = collect_values(data_set, "hasPart.contentUrl")
+    assert ["file3"] == r, "one element should be in the list"
     r = collect_values(data_set, "hasPart.url")
     assert ["file0", "file1", "file2"] == r, "three elements should be in the list"
+    r = collect_values(data_set, "fake.path")
+    assert len(r) == 0
     with pytest.raises(ValueError):
-        collect_values(data_set, "fake.path", ValueError)
+        r = collect_values(None, "hasPart.url",ValueError)

--- a/tests/specializations/resources/test_datasets.py
+++ b/tests/specializations/resources/test_datasets.py
@@ -12,22 +12,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
-# Test suite for initializing a forge.
-
-import pytest
-
-from kgforge.core import KnowledgeGraphForge
-
-SCOPE = "terms"
-MODEL = "DemoModel"
-STORE = "DemoStore"
-RESOLVER = "DemoResolver"
-
-
-class TestForgeInitialization:
-
-    def test_initialization(self, config):
-        forge = KnowledgeGraphForge(config)
-        assert type(forge._model).__name__ == MODEL
-        assert type(forge._store).__name__ == STORE
-        assert type(forge._resolvers[SCOPE][RESOLVER]).__name__ == RESOLVER
+# Placeholder for the generic parameterizable test suite for resources.


### PR DESCRIPTION
Fixes #84 
* Downloading no longer failing when one resource does not have the path to follow
* Downloading fails with DownloadingError when all resources do not have the path to follow
* Externalised forge config fixture to tests/conftest.py to modularise forge session creation during test