### PR TITLE
Updated Dataset provenance setting:

### DIFF
--- a/docs/source/interaction.rst
+++ b/docs/source/interaction.rst
@@ -166,33 +166,33 @@ Dataset
 A Dataset is a specialization of a `Resource` that provides users with operations to handle files
 and describe them with metadata. The metadata of `Datasets` refers specifically to, but not limited to:
 
-* provenance: contribution (people or organizations that contributed to the creation of the Dataset),
+* provenance:
 
+  * contribution (people, organizations or software agents that contributed to the creation of the Dataset),
   * `generation <https://www.w3.org/TR/prov-o/#Generation>`__ (links to resources used to generate this Dataset),
   * `derivation <https://www.w3.org/TR/prov-o/#Derivation>`__ (links another resource from which the Dataset is generated),
   * `invalidation <https://www.w3.org/TR/prov-o/#Invalidation>`__ (data became invalid)
 
 * access: `distribution <https://schema.org/distribution>`__ (a downloadable form of this Dataset, at a specific location, in a specific format)
 
-The `Dataset` class provides methods for adding files to a `Dataset`.
-The added files will only be uploaded in the Store when the `forge.register` function is
-called on the Dataset so that the user flow is not slowed down and for efficiency purpose. We implemented this using
+The `Dataset` class provides methods for adding files to a `Dataset`. The added files will only be uploaded in the Store when the `forge.register` function is
+called on the Dataset so that the user flow is not slowed down and for efficiency purpose. This is done using
 the concept of `LazyAction`, which is a class that will hold an action that will be executed when required.
 
-After the registration of the Dataset, a `DataDownload` resource will be created with some other automatically
-extracted properties, such as  content type, size, file name, etc.
+After the registration of the Dataset, a `DataDownload` resource will be created with automatically
+extracted properties, such as content type, size, file name, etc.
 
 .. code-block:: python
 
    Dataset(forge: KnowledgeGraphForge, type: str = "Dataset", **properties)
      add_parts(resources: List[Resource], versioned: bool = True) -> None
      add_distribution(path: str, content_type: str = None) -> None
-     add_contribution(agent: str, **kwargs) -> None
-     add_generation(**kwargs) -> None
-     add_derivation(resource: Resource, versioned: bool = True, **kwargs) -> None
-     add_invalidation(**kwargs) -> None
+     add_contribution(resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None
+     add_generation(resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None
+     add_derivation(resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None
+     add_invalidation(resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None
      add_files(path: str, content_type: str = None) -> None
-     download(source: str, path: str, overwrite: bool = False) -> None
+     download(path: str, source: str, overwrite: bool = False) -> None
 
 Storing
 -------

--- a/kgforge/specializations/resources/datasets.py
+++ b/kgforge/specializations/resources/datasets.py
@@ -16,7 +16,7 @@ from typing import List, Union
 
 from kgforge.core import Resource
 from kgforge.core.commons.actions import LazyAction
-from kgforge.core.commons.execution import catch
+from kgforge.core.commons.execution import catch, not_supported
 from kgforge.core.forge import KnowledgeGraphForge
 
 
@@ -87,8 +87,10 @@ class Dataset(Resource):
         invalidation = self._add_prov_property(resource,"Invalidation","activity","Activity",keep,versioned, **kwargs)
         _set(self, "invalidation", invalidation)
 
-    def _add_prov_property(self,resource, prov_type, reference_property, reference_type, keep,versioned, **kwargs):
+    def _add_prov_property(self,resource, prov_type, reference_property, reference_type, keep, versioned, **kwargs):
 
+        if versioned and isinstance(resource,str):
+            not_supported(("versioned with resource:str", True))
         if isinstance(resource, str):
             reference = Resource(type=reference_type, id=resource)
         elif isinstance(resource, Resource):

--- a/kgforge/specializations/resources/datasets.py
+++ b/kgforge/specializations/resources/datasets.py
@@ -52,36 +52,50 @@ class Dataset(Resource):
         _set(self, "distribution", action)
 
     @catch
-    def add_contribution(self, agent_id: str, **kwargs) -> None:
-        # agent: IRI.
+    def add_contribution(self, resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None:
+        # resource: Union[str, Resource].
         """Add information on the contribution of an agent during the generation of the dataset."""
-        agent = Resource(type="Agent", id=agent_id)
-        contribution = Resource(type="Contribution", agent=agent, **kwargs)
+
+        keep = ["id", "type", "_store_metadata"]
+        contribution = self._add_prov_property(resource, "Contribution", "agent", "Agent", keep, versioned,
+                                             **kwargs)
         _set(self, "contribution", contribution)
 
     @catch
-    def add_generation(self, **kwargs) -> None:
-        """Add information on the activity which has resulted in the generation of the dataset."""
-        if not kwargs:
-            raise TypeError("at least one argument should be given")
-        generation = Resource(type="Generation", **kwargs)
+    def add_generation(self, resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None:
+        """Add information about the activity that generated the dataset."""
+
+        keep = ["id", "type", "_store_metadata"]
+        generation = self._add_prov_property(resource, "Generation", "activity", "Activity", keep, versioned,
+                                             **kwargs)
         _set(self, "generation", generation)
 
     @catch
-    def add_derivation(self, resource: Resource, versioned: bool = True, **kwargs) -> None:
-        """Add information on the derivation of an entity resulting in the dataset."""
-        keep = ["id", "type", "name","_store_metadata"]
-        entity = self._forge.reshape(resource, keep, versioned)
-        derivation = Resource(type="Derivation", entity=entity, **kwargs)
+    def add_derivation(self, resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None:
+        """Add information about the resources from which the dataset was derived."""
+
+        keep = ["id", "type", "name", "_store_metadata"]
+        derivation = self._add_prov_property(resource, "Derivation", "entity", "Entity", keep, versioned,
+                                             **kwargs)
         _set(self, "derivation", derivation)
 
     @catch
-    def add_invalidation(self, **kwargs) -> None:
-        """Add information on the invalidation of the dataset."""
-        if not kwargs:
-            raise TypeError("at least one argument should be given")
-        invalidation = Resource(type="Invalidation", **kwargs)
+    def add_invalidation(self, resource: Union[str, Resource], versioned: bool = True, **kwargs) -> None:
+        """Add information about the invalidation of the dataset."""
+
+        keep = ["id", "type", "_store_metadata"]
+        invalidation = self._add_prov_property(resource,"Invalidation","activity","Activity",keep,versioned, **kwargs)
         _set(self, "invalidation", invalidation)
+
+    def _add_prov_property(self,resource, prov_type, reference_property, reference_type, keep,versioned, **kwargs):
+
+        if isinstance(resource, str):
+            reference = Resource(type=reference_type, id=resource)
+        elif isinstance(resource, Resource):
+            reference = self._forge.reshape(resource, keep, versioned)
+        result = Resource(type=prov_type, **kwargs)
+        result.__setattr__(reference_property,reference)
+        return result
 
     @catch
     def add_files(self, path: str, content_type: str = None) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,21 @@ def metadata_data_expanded():
         "https://store.net/vocabulary/version": 1
     }
 
+@pytest.fixture
+def store_metadata_context():
+    return {
+        "meta": "https://store.net/vocabulary/",
+        "deprecated": "meta:deprecated",
+        "version": "meta:version"
+    }
+
+
+@pytest.fixture
+def store_metadata_value(store_metadata_context, metadata_data_compacted):
+    data = {"context": store_metadata_context}
+    data.update(metadata_data_compacted)
+    return data
+
 
 @pytest.fixture
 def person(custom_context):
@@ -324,6 +339,7 @@ def config(model, store, resolver):
         },
         "Store": {
             "name": store,
+            "versioned_id_template": "{x.id}?_version={x._store_metadata.version}"
         },
         "Resolvers": {
             SCOPE: [

--- a/tests/core/archetypes/test_store.py
+++ b/tests/core/archetypes/test_store.py
@@ -17,7 +17,10 @@ import pytest
 
 from kgforge.core import Resource, KnowledgeGraphForge
 from kgforge.core.archetypes.store import rewrite_sparql
-from kgforge.core.commons.exceptions import DownloadingError
+from kgforge.core.commons.exceptions import DownloadingError, FreezingError
+from kgforge.specializations.resources import Dataset
+from kgforge.core.wrappings.dict import DictWrapper, wrap_dict
+import json
 
 context = {
     "@context": {
@@ -75,3 +78,54 @@ def test_download(config):
     with pytest.raises(DownloadingError):
         forge = KnowledgeGraphForge(config)
         forge._store.download(simple, "fake.path", "./", overwrite=False)
+
+def test_freeze(config, store_metadata_value):
+
+    forge = KnowledgeGraphForge(config, debug=True)
+    derivation1 = Dataset(forge, type="Dataset", name="A derivation dataset")
+    derivation1.id = "http://derivation1"
+    derivation1._store_metadata = wrap_dict(store_metadata_value)
+
+    generation1 = Dataset(forge, type="Dataset", name="A generation dataset")
+    generation1.id = "http://generation1"
+    generation1._store_metadata = wrap_dict(store_metadata_value)
+
+    invalidation1 = Dataset(forge, type="Activity", name="An invalidation activity")
+    invalidation1.id = "http://invalidation1"
+    invalidation1._store_metadata = wrap_dict(store_metadata_value)
+
+    contribution1 = Resource(type="Person", name="A contributor")
+    contribution1.id = "http://contribution1"
+    contribution1._store_metadata = wrap_dict(store_metadata_value)
+
+    dataset = Dataset(forge, type="Dataset", name="A dataset")
+    dataset._store_metadata = wrap_dict(store_metadata_value)
+    dataset.add_derivation(derivation1, versioned=False)
+    dataset.add_generation(generation1, versioned=False)
+    dataset.add_invalidation(invalidation1, versioned=False)
+    dataset.add_contribution(contribution1, versioned=False)
+
+    expected_derivation = json.loads(json.dumps({"type":"Derivation", "entity":{"id": "http://derivation1",
+                                                                                "type":"Dataset", "name":"A derivation dataset"}}))
+    assert forge.as_json(dataset.derivation) == expected_derivation
+
+    expected_generation = json.loads(json.dumps({"type": "Generation",
+                                                 "activity": {"id": "http://generation1", "type": "Dataset"}}))
+    assert forge.as_json(dataset.generation) == expected_generation
+
+    expected_contribution = json.loads(json.dumps({"type": "Contribution",
+                                                 "agent": {"id": "http://contribution1", "type": "Person"}}))
+    assert forge.as_json(dataset.contribution) == expected_contribution
+
+    expected_invalidation = json.loads(json.dumps({"type": "Invalidation",
+                                                   "activity": {"id": "http://invalidation1", "type": "Activity"}}))
+    assert forge.as_json(dataset.invalidation) == expected_invalidation
+
+    dataset.id = "http://dataset"
+    dataset._synchronized = True
+    forge._store.freeze(dataset)
+    assert dataset.id == "http://dataset?_version=1"
+    assert dataset.derivation.entity.id == "http://derivation1?_version=1"
+    assert dataset.generation.activity.id == "http://generation1?_version=1"
+    assert dataset.contribution.agent.id == "http://contribution1?_version=1"
+    assert dataset.invalidation.activity.id == "http://invalidation1?_version=1"

--- a/tests/core/conversions/conftest.py
+++ b/tests/core/conversions/conftest.py
@@ -66,23 +66,6 @@ def r5():
 
 # Fixtures for Resource to JSON-LD conversion and vice versa
 
-
-@pytest.fixture
-def store_metadata_context():
-    return {
-        "meta": "https://store.net/vocabulary/",
-        "deprecated": "meta:deprecated",
-        "version": "meta:version"
-    }
-
-
-@pytest.fixture
-def store_metadata_value(store_metadata_context, metadata_data_compacted):
-    data = {"context": store_metadata_context}
-    data.update(metadata_data_compacted)
-    return data
-
-
 @pytest.fixture
 def make_registered():
     def _make_registered(r: Resource, metadata, base=None):


### PR DESCRIPTION
Fixes #80 

* add_generation, add_derivation, add_invalidation, add_contribution are now all accepting a resource IRI or a Resource
* when providing an IRI, forge.freeze will fail as there is no way to know about which version to freeze with