### PR TITLE
Added support for dict as filters in forge.search

### DIFF
--- a/examples/notebooks/getting-started/04 - Querying.ipynb
+++ b/examples/notebooks/getting-started/04 - Querying.ipynb
@@ -325,6 +325,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Paths as filters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The `paths` method load the data structure for the given type.\n",
     "\n",
     "Please refer to the [Modeling.ipynb](11%20-%20Modeling.ipynb) notebook to learn about modeling and types."
@@ -390,6 +397,54 @@
    "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forge.as_dataframe(resources, store_metadata=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### dict as filters\n",
+    "A dictionary can be provided for filters:\n",
+    "* {'type': {'id':'Dataset'}} is equivalent to p.type.id==\"Dataset\"\n",
+    "* only the '==' operator is supported\n",
+    "* nested dict are supported\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filters = {\"type\": \"Dataset\"}\n",
+    "resources = forge.search(filters, limit=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(resources)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(resources)"
    ]
   },
   {
@@ -783,9 +838,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.6 (nexusforge_2)",
+   "display_name": "Python (nexusforgelatest)",
    "language": "python",
-   "name": "nexusforge_2"
+   "name": "nexusforgelatest"
   },
   "language_info": {
    "codemirror_mode": {

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -227,7 +227,10 @@ class Store(ABC):
 
     def search(self, resolvers: Optional[List["Resolver"]], *filters, **params) -> List[Resource]:
 
-        # Positional arguments in 'filters' are instances of type Filter from wrappings/paths.py.
+        # Positional arguments in 'filters' are instances of type Filter from wrappings/paths.py
+        # A dictionary can be provided for filters:
+        #  - {'key1': 'val', 'key2': {'key3': 'val'}} will be translated to
+        #  - [Filter(operator='__eq__', path=['key1'], value='val'), Filter(operator='__eq__', path=['key2', 'key3'], value='val')]
         # Keyword arguments in 'params' could be:
         #   - debug: bool,
         #   - limit: int,

--- a/kgforge/core/wrappings/paths.py
+++ b/kgforge/core/wrappings/paths.py
@@ -24,6 +24,9 @@ class Filter:
         self.operator: str = operator
         self.value: Any = value
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.path == other.path and self.operator == other.operator and self.value == other.value
+
     def __repr__(self) -> str:
         return repr_class(self)
 
@@ -83,3 +86,18 @@ def _wrap(data: Any, path: List[str]) -> Union[PathsWrapper, PathWrapper]:
         return PathsWrapper(path, {k: _wrap(v, path + [k]) for k, v in data.items()})
     else:
         return PathWrapper(path)
+
+
+def create_filters_from_dict(filter_dict: Dict, path_prefix=None) -> List[Filter]:
+    filters = list()
+    if path_prefix is None:
+        path_prefix = []
+    for k, v in filter_dict.items():
+        path_prefix.append(k)
+        path = list(path_prefix)
+        if isinstance(v, dict):
+            filters.extend(create_filters_from_dict(v, path))
+        else:
+            filters.append(Filter(path, "__eq__", v))
+        path_prefix.remove(k)
+    return filters

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -40,6 +40,7 @@ from kgforge.core.commons.exceptions import (DeprecationError, DownloadingError,
 from kgforge.core.commons.execution import run, not_supported
 from kgforge.core.commons.files import is_valid_url
 from kgforge.core.conversions.rdf import as_jsonld, from_jsonld
+from kgforge.core.wrappings.paths import Filter, create_filters_from_dict
 from kgforge.specializations.mappers import DictionaryMapper
 from kgforge.specializations.mappings import DictionaryMapping
 from kgforge.specializations.stores.nexus.service import BatchAction, DEPRECATED_PROPERTY, PROJECT_PROPERTY, Service
@@ -365,6 +366,8 @@ class BlueBrainNexus(Store):
         elif not cross_bucket:
             project_statements = f"Filter (?project = <{'/'.join([self.endpoint,'projects',self.organisation, self.project])}>)"
 
+        if filters and isinstance(filters[0], dict):
+            filters = create_filters_from_dict(filters[0])
         query_statements, query_filters = build_query_statements(self.model_context, filters)
         query_statements.insert(0, f"<{PROJECT_PROPERTY}> ?project")
         query_statements.insert(1, f"<{DEPRECATED_PROPERTY}> {format_type[CategoryDataType.BOOLEAN](deprecated)}")

--- a/tests/core/wrappings/test_paths.py
+++ b/tests/core/wrappings/test_paths.py
@@ -13,3 +13,32 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 # Placeholder for the test suite for wrapping of property paths.
+
+import pytest
+
+from kgforge.core.wrappings.paths import Filter, create_filters_from_dict
+
+@pytest.mark.parametrize("dict_filters, expected", [
+        pytest.param(({"agent":{"name":"EPFL"}}),
+                     ([Filter(["agent", "name"], "__eq__", "EPFL")]),
+                     id="literal"),
+        pytest.param(({"agent": {"name": "EPFL", "address":{"postalCode":"1015"}}}),
+                     ([Filter(["agent", "name"], "__eq__", "EPFL"),
+                       Filter(["agent", "address","postalCode"], "__eq__", "1015")]),
+                     id="one_nested"),
+        pytest.param(({"type":"Contribution","agent": {"type":"Agent","name": "EPFL", "address": {
+                        "type":"PostalAddress","postalCode": "1015","addressCountry":{
+                        "type":"Country","name":"Switzerland"}
+                        }}}),
+                     ([Filter(["type"], "__eq__", "Contribution"),
+                       Filter(["agent", "type"], "__eq__", "Agent"),
+                       Filter(["agent", "name"], "__eq__", "EPFL"),
+                       Filter(["agent", "address", "type"], "__eq__", "PostalAddress"),
+                       Filter(["agent", "address", "postalCode"], "__eq__", "1015"),
+                       Filter(["agent", "address", "addressCountry","type"], "__eq__", "Country"),
+                       Filter(["agent", "address", "addressCountry", "name"], "__eq__", "Switzerland")]),
+                     id="many_nested")
+    ])
+def test_dict_to_filter(dict_filters, expected):
+    filters = create_filters_from_dict(dict_filters)
+    assert filters == expected


### PR DESCRIPTION
A dictionary can be provided for filters in `forge.search(self, resolvers: Optional[List["Resolver"]], *filters, **params) -> List[Resource]`:

* {'key1': 'val', 'key2': {'key3': 'val'}} will be translated to:

    - [Filter(operator='__eq__', path=['key1'], value='val'), Filter(operator='__eq__', path=['key2', 'key3'], value='val')]

* only the '==' operator is supported
* nested dict are supported
