### PR TITLE
Added support for filtering with type values or keys not defined in configured Model

### DIFF
--- a/kgforge/core/commons/context.py
+++ b/kgforge/core/commons/context.py
@@ -59,3 +59,6 @@ class Context(RdflibContext):
             return self.iri.startswith("http")
         else:
             return False
+
+    def has_vocab(self):
+        return self.vocab is not None

--- a/kgforge/core/commons/files.py
+++ b/kgforge/core/commons/files.py
@@ -19,7 +19,7 @@ from requests import RequestException
 from urllib.parse import urlparse
 
 def load_file_as_byte(source: str):
-    # source: Union[str, FilePath, URL].
+    # source: Union[str, Path, URL].
     filepath = Path(source)
     if filepath.is_file():
         data = filepath.read_bytes()
@@ -32,10 +32,9 @@ def load_file_as_byte(source: str):
             raise AttributeError(f"Failed to load the configuration from {source}. The provided source is not a valid file path or URL: {str(re)}")
     return data
 
-#https://stackoverflow.com/questions/7160737/how-to-validate-a-url-in-python-malformed-or-not
 def is_valid_url(url):
     try:
         result = urlparse(url)
-        return all([result.scheme, result.netloc, result.path])
-    except:
+        return all([result.scheme, result.netloc])
+    except Exception as e:
         return False

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -29,6 +29,7 @@ from aiohttp.hdrs import CONTENT_DISPOSITION, CONTENT_TYPE
 from pyld import jsonld
 from rdflib import Graph
 from rdflib.plugins.sparql.parser import Query
+from rdflib_jsonld.context import Term
 from requests import HTTPError
 
 from kgforge.core import Resource
@@ -487,7 +488,7 @@ def build_query_statements(context: Context, *conditions) -> Tuple[List,List]:
 
         property_path = "/".join(f.path)
 
-        if f.path[-1] == "type" or last_term.type == "@id":
+        if f.path[-1] == "type" or ('type' in last_term and last_term.type == "@id"):
             if f.operator == "__eq__":
                 statements.append(f"{property_path} {_box_value_as_full_iri(f.value)}")
             elif f.operator == "__ne__":
@@ -506,6 +507,7 @@ def build_query_statements(context: Context, *conditions) -> Tuple[List,List]:
                 filters.append(f"FILTER(?v{index} {operator_map[f.operator]} {_box_value_as_full_iri(value)})")
 
     return statements, filters
+
 
 def _box_value_as_full_iri(value):
     return f"<{value}>" if is_valid_url(value) else value

--- a/tests/core/conversions/test_rdf.py
+++ b/tests/core/conversions/test_rdf.py
@@ -115,37 +115,6 @@ class TestJsonLd:
         resource = from_jsonld(payload)
         assert resource == building
 
-    def test_from_jsonld_2(self, building, model_context, building_jsonld):
-        payload = {
-            "@context": {
-                "sh": "http://www.w3.org/ns/shacl#",
-                "ex": "http://test/vocab#",
-                "parent": {
-                    "@id": "ex:parent",
-                    "@type": "@id"
-                },
-                "nodeKind": {
-                    "@id": "sh:nodeKind",
-                    "@type": "@id"
-                },
-                "BlankNode": {
-                    "@id": "sh:BlankNode"
-                },
-                "NodeShape": {
-                    "@id": "sh:NodeShape"
-                },
-                "SuperClass": {
-                    "@id": "ex:SuperClass"
-                }
-            },
-            "@id": "http://test/data/123",
-            "@type": "NodeShape",
-            "parent": "ex:SuperClass",
-            "nodeKind": "sh:BlankNode"
-        }
-        resource_dict = from_jsonld(payload)
-        assert True
-
     def test_unresolvable_context(self, building, building_jsonld):
         building.context = "http://unresolvable.context.example.org/"
         payload = building_jsonld(building, "compacted", False, None)


### PR DESCRIPTION
Added support for filtering using dict with type values or keys not defined in configured Model

* Added the configured context's @vocab as base SPARQL prefix if any
* Updated the query rewriting regex to prevent rewriting urls
* Added has_vocab function to Context