### PR TITLE
Added file to resource mapping for publishing

### DIFF
--- a/examples/configurations/nexus-store/publishing-file-to-resource-mapping.hjson
+++ b/examples/configurations/nexus-store/publishing-file-to-resource-mapping.hjson
@@ -1,0 +1,16 @@
+{
+    type: DataDownload
+    contentSize:
+    {
+        unitCode: f"bytes"
+        value: x._bytes
+    }
+    digest:
+    {
+        algorithm: x._digest._algorithm
+        value: x._digest._value
+    }
+    encodingFormat: x._mediaType
+    name: x._filename
+    contentUrl: x._self
+}


### PR DESCRIPTION
For dissemination data, the **distribution** object on resources should not include the store and location metadata. The _publishing-file-to-resource-mapping.hjson_ can be used for this use case (instead of to the file-to-resource-mapping.hjson file in the same directory)