### PR TITLE
Fixed asyncio issue with Jupyter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
         "nest_asyncio",
         "pyLD",
         "pyshacl==0.11.6.post1",
-        "rdflib-jsonld"
+        "rdflib-jsonld",
+        "nest-asyncio>=1.5.1"
     ],
     extras_require={
         "dev": ["tox", "pytest", "pytest-bdd==3.4.0", "pytest-cov", "pytest-mock", "codecov"],


### PR DESCRIPTION
Fixed `RuntimeError: This event loop is already running` on batch operations executed in Jupyter (pinned `nest-asyncio>=1.5.1`).

The error happens, when there is a new version of `tornado` (>=5) and an old version of `nest-asyncio`, so there are two solutions:
- downgrade `tornado` to `4.X`,
- upgrade `nest-asyncio` to `1.5.X` (which is a better solution, in order not to depend on an outdated package)