### PR TITLE
Removed rdflib-jsonld, moved to rdflib

### DIFF
--- a/kgforge/core/commons/context.py
+++ b/kgforge/core/commons/context.py
@@ -14,8 +14,8 @@
 
 from typing import Optional, Union, Dict, List
 
-from rdflib_jsonld.context import Context as RdflibContext
-from rdflib_jsonld.util import source_to_json
+from rdflib.plugins.shared.jsonld.context import Context as RdflibContext
+from rdflib.plugins.shared.jsonld.util import source_to_json
 
 
 class Context(RdflibContext):

--- a/kgforge/core/conversions/rdf.py
+++ b/kgforge/core/conversions/rdf.py
@@ -23,7 +23,7 @@ import json
 from collections import OrderedDict
 
 from rdflib.namespace import RDF
-from rdflib_jsonld.keys import CONTEXT, GRAPH, TYPE, ID
+from rdflib.plugins.shared.jsonld.keys import CONTEXT, GRAPH, TYPE, ID
 
 from kgforge.core.commons.actions import LazyAction
 from kgforge.core.commons.context import Context

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "nest_asyncio",
         "pyLD",
         "pyshacl==0.11.6.post1",
-        "rdflib-jsonld",
         "nest-asyncio>=1.5.1"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "aiohttp",
         "nest_asyncio",
         "pyLD",
+        "rdflib>=6.0.1",
         "pyshacl==0.11.6.post1",
         "nest-asyncio>=1.5.1"
     ],


### PR DESCRIPTION
`rdflib-jsonld` is deprecated and becomes a part of `rdflib==6.0.1`

- Removed `rdflib-jsonld` from `setup.py`
- Added `rdflib>=6.0.1` in `setup.py`
- Changed import paths

__Note__ Installing `rdflib==6.0.1` creates a dependency conflict:

```
pyshacl 0.11.6.post1 requires rdflib<6.0.0,>=4.2.2, but you have rdflib 6.0.1 which is incompatible.
```

Due to the fixed version  `pyshacl==0.11.6.post1` in `setup.py`