### PR TITLE
Fixed rdflib and rdflib_jsonld versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,10 @@ setup(
         "nexus-sdk",
         "aiohttp",
         "nest_asyncio",
+        "rdflib<6.0.0",
         "pyLD",
         "pyshacl==0.11.6.post1",
-        "rdflib-jsonld",
+        "rdflib-jsonld<=0.5.0",
         "nest-asyncio>=1.5.1"
     ],
     extras_require={


### PR DESCRIPTION
`rdflib-jsonld` is deprecated and becomes a part of `rdflib==6.0.1`, installing `rdflib==6.0.1` creates a dependency conflict:

```
pyshacl 0.11.6.post1 requires rdflib<6.0.0,>=4.2.2, but you have rdflib 6.0.1 which is incompatible.
```

Due to the fixed version  `pyshacl==0.11.6.post1` in `setup.py`

This PR contains the following fix ():

- fixed `rdflib<6.0.0`
- fixed `rdflib-jsonld<=0.5.0`
