### PR TITLE
Upgraded to rdflib>=6.0.0 and pyshacl==v0.17.2:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
 

--- a/kgforge/core/commons/context.py
+++ b/kgforge/core/commons/context.py
@@ -13,12 +13,10 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 from typing import Optional, Union, Dict, List
-
-from rdflib_jsonld.context import Context as RdflibContext
-from rdflib_jsonld.util import source_to_json
+from rdflib.plugins.shared.jsonld.context import source_to_json, Context as JSONLD_Context
 
 
-class Context(RdflibContext):
+class Context(JSONLD_Context):
     """Context class will hold a JSON-LD context in two forms: iri and document.
 
     See also: https://w3c.github.io/json-ld-syntax/#the-context

--- a/kgforge/core/conversions/rdf.py
+++ b/kgforge/core/conversions/rdf.py
@@ -13,6 +13,8 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 from copy import deepcopy
+
+from rdflib.plugins.shared.jsonld.keys import CONTEXT, TYPE, GRAPH
 from typing import Union, Dict, List, Tuple, Optional, Callable, Any
 from urllib.error import URLError, HTTPError
 
@@ -21,9 +23,7 @@ from pyld import jsonld
 from rdflib import Graph, Literal
 import json
 from collections import OrderedDict
-
 from rdflib.namespace import RDF
-from rdflib_jsonld.keys import CONTEXT, GRAPH, TYPE, ID
 
 from kgforge.core.commons.actions import LazyAction
 from kgforge.core.commons.context import Context
@@ -214,7 +214,7 @@ def _as_jsonld_one(resource: Resource, form: Form, store_metadata: bool,
             context.expand(resource_type) for resource_type in resource_types]
     resource.type = resource_types
     if store_metadata is True and len(metadata_graph) > 0:
-        metadata_expanded = json.loads(metadata_graph.serialize(format="json-ld").decode("utf-8"))
+        metadata_expanded = json.loads(metadata_graph.serialize(format="json-ld"))
         metadata_framed = jsonld.frame(metadata_expanded, {"@id": resource.id})
         if form is Form.COMPACTED:
             data_compacted = jsonld.compact(data_framed, resolved_context)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     keywords="framework knowledge graph data science",
     url="https://github.com/BlueBrain/nexus-forge",
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     setup_requires=[
         "setuptools_scm",
     ],
@@ -46,13 +46,12 @@ setup(
         "nexus-sdk",
         "aiohttp",
         "nest_asyncio",
-        "rdflib<6.0.0",
+        "rdflib>=6.0.0",
         "pyLD",
-        "pyshacl==0.11.6.post1",
-        "rdflib-jsonld<0.6.1",
+        "pyshacl==v0.17.2",
         "nest-asyncio>=1.5.1",
-        "pyparsing==2.*",
-        "owlrl>=5.2.1, < 6.0.2"
+        "pyparsing>=2.0.2",
+        "owlrl>=5.2.3"
     ],
     extras_require={
         "dev": ["tox", "pytest", "pytest-bdd==3.4.0", "pytest-cov", "pytest-mock", "codecov"],


### PR DESCRIPTION
This commit is for catching up with the latest releases of pyshacl and rdflib.

* Removed rdflib-jsonld dependancy which is now part of rdflib from rdflib>=6.0.0
* Added a ShapeWrapper class extending pyshacl.shape to workaround added __slots__ preventing from dynamically adding methods
* Set min python version to v3.7 as required by pyshacl from 0.17.0