### PR TITLE
Updated staging endpoint and resource property names.

### DIFF
--- a/examples/notebooks/use-cases/BBP KG Create Datasets.ipynb
+++ b/examples/notebooks/use-cases/BBP KG Create Datasets.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nexus_staging_endpoint = \"https://staging.nexus.ocp.bbp.epfl.ch/v1\" # use staging to try and test. \n",
+    "nexus_staging_endpoint = \"https://staging.nise.bbp.epfl.ch/nexus/v1\" # use staging to try and test. \n",
     "nexus_endpoint = nexus_staging_endpoint"
    ]
   },

--- a/examples/notebooks/use-cases/BBP KG Ontology Brain Building Workflow Search and Exploration.ipynb
+++ b/examples/notebooks/use-cases/BBP KG Ontology Brain Building Workflow Search and Exploration.ipynb
@@ -1224,7 +1224,7 @@
     }
    ],
    "source": [
-    "forge.as_json(generator_resource)[\"nsg:about\"]"
+    "forge.as_json(generator_resource)[\"about\"]"
    ]
   },
   {
@@ -1789,7 +1789,7 @@
     }
    ],
    "source": [
-    "[forge.as_json(r)[\"id\"] for r in generator_variant_resource.usesCircuitWithProperty]"
+    "generator_variant_resource.usesCircuitWithProperty"
    ]
   }
  ],


### PR DESCRIPTION
1. Staging address of the `Create Datasets` was outdated, so it was changed to the correct endpoint address, which used in the other notebooks.
2. Updated to the fact that `nsg:about` is now just `about`.
3. The list of `usesCircuitWithProperty` can be called directly as a property.
