### PR TITLE
Not use resource object when resource object creation fails in retrieve, search

### DIFF
--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -87,7 +87,7 @@ SPARQL_CLAUSES = [
     "by",
     "order",
     "minus",
-    "not"
+    "not",
     "exists"
 ]
 

--- a/kgforge/core/conversions/rdf.py
+++ b/kgforge/core/conversions/rdf.py
@@ -465,6 +465,9 @@ def _remove_ld_keys(
                 local_attrs["context"] = v
         else:
             if k == "@id":
+                if not isinstance(v, str):
+                    raise ValueError(f"Invalid value found in data: value of type {type(v)} "
+                                     f"found associated to a \"@id\" key. Only strings are valid")
                 local_attrs["id"] = context.resolve(v)
             elif k.startswith("@") and k in LD_KEYS.values():
                 local_attrs[k[1:]] = v

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -368,15 +368,21 @@ class BlueBrainNexus(Store):
             try:
                 data = response.json()
                 resource = self.service.to_resource(data)
+            except Exception as e:
+                raise ValueError(e)
+
+            try:
                 if retrieve_source and not cross_bucket:
                     data = response_metadata.json()
                 if retrieve_source and cross_bucket:
                     resource = self.service.to_resource(response_metadata.json())
             except Exception as e:
                 self.service.synchronize_resource(
-                    resource, data, self.retrieve.__name__, False, False
+                        resource, data, self.retrieve.__name__, False, False
                 )
                 raise ValueError(e)
+
+
             finally:
                 self.service.synchronize_resource(
                     resource, data, self.retrieve.__name__, True, True


### PR DESCRIPTION
In both retrieval and search, when building the resource object, if an exception is thrown, in the catching block a reference to the "resource" variable was made when its building was unsuccessful, so a variable is referenced before assignment. This would lead to an error that would shield the real error message from the exception from being propagated.
+ Addressing [this issue](https://github.com/BlueBrain/nexus-forge/issues/299), throwing a more explicit error of what went wrong. There was an assumption a string would be manipulated, but now a check on the type is being performed. 