### PR TITLE
Use `scikit-learn` instead of `sklearn` for "linking_sklearn" extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "codecov",
         ],
         "docs": ["sphinx", "sphinx-bluebrain-theme"],
-        "linking_sklearn": ["sklearn"],
+        "linking_sklearn": ["scikit-learn"],
     },
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Building the docker image on Binder may fail because package `sklearn` is deprecated. The package has been renamed to `scikit-learn`.

The failure cannot be reliably reproduced because the installation of `sklearn` will only raise an exception during specific time windows. See section "Brownout schedule" on https://pypi.org/project/sklearn/.

This PR replaces `sklearn` with `scikit-learn`.