### PR TITLE
Removed codecov from test and library requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,3 @@ jobs:
       - name: Run tests with pytest
         run: |
           pytest --cov=./
-          codecov

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
             "pytest-bdd==3.4.0",
             "pytest-cov",
             "pytest-mock",
-            "codecov",
         ],
         "docs": ["sphinx", "sphinx-bluebrain-theme"],
         "linking_sklearn": ["sklearn"],


### PR DESCRIPTION
The codecov package has been removed from PyPi as deprecated. This is causing the installing requirements to fail.