### PR TITLE
Added filters to agent resolver

### DIFF
--- a/kgforge/specializations/resolvers/agent_resolver.py
+++ b/kgforge/specializations/resolvers/agent_resolver.py
@@ -77,7 +77,8 @@ class AgentResolver(Resolver):
               }}
             }}
             """
-        context = self.service.get_context(resolving_context, target)
+        filters = self.service.filters[target] if target in self.service.filters else None
+        context = self.service.get_context(resolving_context, target, filters)
         query, strategy_dependant_limit = _build_resolving_query(text, query_template, self.service.deprecated_property, self.service.filters[target], strategy, type, properties_to_filter_with, context, SPARQLQueryBuilder, limit)
         expected_fields = properties_to_filter_with+["type"]
         return self.service.perform_query(query, target, expected_fields, strategy_dependant_limit)

--- a/kgforge/specializations/resolvers/store_service.py
+++ b/kgforge/specializations/resolvers/store_service.py
@@ -24,11 +24,10 @@ class StoreService:
         self.filters: Dict[str, str] = dict()
         for identifier in targets:
             bucket = targets[identifier]["bucket"]
-            filters = targets[identifier]["filters"]
+            if 'filters' in targets[identifier]:
+                self.filters[identifier] = targets[identifier]["filters"]
             store_config.update(bucket=bucket)
             self.sources[identifier] = store(**store_config)
-            if filters:
-                self.filters[identifier] = filters
         self.deprecated_property = "https://bluebrain.github.io/nexus/vocabulary/deprecated"
 
     def perform_query(self, query: str, target: str, expected_fields: List[str],


### PR DESCRIPTION
This is related to this comment:
https://github.com/BlueBrain/nexus-forge/commit/051eb73d2091c2cecccdf54358f4980b8e876959#commitcomment-117123788
The ontology resolver was not updated when the filters were added, so it breaks when calling the function `get_context`

- Added filters to the call in the agent resolver
- changed the way that filters are defined to avoid KeyErrors