### PR TITLE
Added project configuration for neurosciencegraph/datamodels

### DIFF
--- a/examples/notebooks/use-cases/nsg-forge-nexus.yml
+++ b/examples/notebooks/use-cases/nsg-forge-nexus.yml
@@ -1,0 +1,71 @@
+Model:
+  name: RdfModel
+  origin: store
+  source: BlueBrainNexus
+  context:
+    iri: "https://neuroshapes.org"
+    bucket: "neurosciencegraph/datamodels"
+
+Store:
+  name: BlueBrainNexus
+  endpoint: https://bbp.epfl.ch/nexus/v1
+  searchendpoints:
+    sparql:
+      endpoint: "https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex"
+    elastic:
+      endpoint: "https://bbp.epfl.ch/neurosciencegraph/data/views/aggreg-es/dataset"
+      mapping: "https://bbp.epfl.ch/neurosciencegraph/data/views/es/dataset"
+      default_str_keyword_field: "keyword"
+  vocabulary:
+    metadata:
+      iri: "https://bluebrain.github.io/nexus/contexts/metadata.json"
+      local_iri: "https://bluebrainnexus.io/contexts/metadata.json"
+    namespace: "https://bluebrain.github.io/nexus/vocabulary/"
+    deprecated_property: "https://bluebrain.github.io/nexus/vocabulary/deprecated"
+    project_property: "https://bluebrain.github.io/nexus/vocabulary/project"
+  max_connection: 5
+  versioned_id_template: "{x.id}?rev={x._store_metadata._rev}"
+  file_resource_mapping: /Users/cgonzale/Documents/code/nexus-forge/examples/configurations/nexus-store/file-to-resource-mapping.hjson
+
+Resolvers:
+  ontology:
+    - resolver: OntologyResolver
+      origin: store
+      source: BlueBrainNexus
+      targets:
+        - identifier: terms
+          bucket: neurosciencegraph/datamodels
+        - identifier: CellType
+          bucket: neurosciencegraph/datamodels
+          filters:
+            - path: subClassOf*.id
+              value: BrainCellType
+        - identifier: BrainRegion
+          bucket: neurosciencegraph/datamodels
+          filters:
+            - path: subClassOf*.id
+              value: BrainRegion
+        - identifier: Species
+          bucket: neurosciencegraph/datamodels
+          filters:
+            - path: subClassOf*.id
+              value: Species
+      searchendpoints:
+        sparql:
+          endpoint: "https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex"
+      result_resource_mapping: https://raw.githubusercontent.com/BlueBrain/nexus-forge/master/examples/configurations/nexus-resolver/term-to-resource-mapping.hjson
+  agent:
+    - resolver: AgentResolver
+      origin: store
+      source: BlueBrainNexus
+      targets:
+        - identifier: agents
+          bucket: bbp/agents
+      searchendpoints:
+        sparql:
+          endpoint: "https://bluebrain.github.io/nexus/vocabulary/defaultSparqlIndex"
+      result_resource_mapping: https://raw.githubusercontent.com/BlueBrain/nexus-forge/master/examples/configurations/nexus-resolver/agent-to-resource-mapping.hjson
+
+Formatters:
+  identifier: https://bbp.epfl.ch/neurosciencegraph/data/{}/{}
+  identifier_bbn_self: https://bbp.epfl.ch/resources/{}/{}/{}/{} #  https://bbp.epfl.ch/nexus/v1/resources/{organization}/{project}/{schema}/{id}

--- a/examples/notebooks/use-cases/nsg-forge-nexus.yml
+++ b/examples/notebooks/use-cases/nsg-forge-nexus.yml
@@ -25,7 +25,7 @@ Store:
     project_property: "https://bluebrain.github.io/nexus/vocabulary/project"
   max_connection: 5
   versioned_id_template: "{x.id}?rev={x._store_metadata._rev}"
-  file_resource_mapping: /Users/cgonzale/Documents/code/nexus-forge/examples/configurations/nexus-store/file-to-resource-mapping.hjson
+  file_resource_mapping: https://raw.githubusercontent.com/BlueBrain/nexus-forge/master/examples/configurations/nexus-store/file-to-resource-mapping.hjson
 
 Resolvers:
   ontology:


### PR DESCRIPTION
### Context
The existing configuration file does not work for the neurosciencegraph/datamodels as the bbp.neuroshapes.org context was deprecated in that project.

### Action
Added a configuration file `nsg-forge-nexus.yml` that can be use in that case.