### PR TITLE
BlueBrainNexusStore: fix tagging schemas

### DIFF
--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -620,10 +620,10 @@ class BlueBrainNexus(Store):
         )
 
     def _tag_one(self, resource: Resource, value: str) -> None:
-        data = {"tag": value, "rev": resource._store_metadata._rev}
-        url = f"{self.service.url_resources}/_/{quote_plus(resource.id)}/tags?rev={resource._store_metadata._rev}"
+        url, data, rev_param, _ = self.service._prepare_tag(resource, value)
         try:
-            params_tag = copy.deepcopy(self.service.params.get("tag", None))
+            params_tag = copy.deepcopy(self.service.params.get("tag", {}))
+            params_tag.update(rev_param)
             response = requests.post(
                 url,
                 headers=self.service.headers,

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -239,7 +239,7 @@ class StoreLibrary:
     def _tag_id(rid: str, tag: str) -> str:
         return f"{rid}_tag={tag}"
     
-    def rewrite_ur(self, uri: str, context: Context, **kwargs) -> str:
+    def rewrite_uri(self, uri: str, context: Context, **kwargs) -> str:
         raise not_supported()
 
     class RecordExists(Exception):


### PR DESCRIPTION
* tagging schemas required a specific schema (https://bluebrain.github.io/nexus/schemas/shacl-20170720.ttl) URI to be present in the request URL
* '_' is present as schema in case of UNCONSTRAINED resource