### PR TITLE
Raised an exception when a jsonld dict with an @id containing space character is provided to from_jsonld

### DIFF
--- a/kgforge/core/conversions/rdf.py
+++ b/kgforge/core/conversions/rdf.py
@@ -13,15 +13,14 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 from copy import deepcopy
-from kgforge.core.commons.files import is_valid_url
 
-from rdflib.plugins.shared.jsonld.keys import CONTEXT, TYPE, GRAPH
+from rdflib.plugins.shared.jsonld.keys import CONTEXT, GRAPH
 from typing import Union, Dict, List, Tuple, Optional, Callable, Any
 from urllib.error import URLError, HTTPError
 
 from enum import Enum
 from pyld import jsonld
-from rdflib import Graph, Literal
+from rdflib import Graph
 import json
 from collections import OrderedDict
 from rdflib.namespace import RDF

--- a/kgforge/core/conversions/rdf.py
+++ b/kgforge/core/conversions/rdf.py
@@ -13,6 +13,7 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 from copy import deepcopy
+from kgforge.core.commons.files import is_valid_url
 
 from rdflib.plugins.shared.jsonld.keys import CONTEXT, TYPE, GRAPH
 from typing import Union, Dict, List, Tuple, Optional, Callable, Any
@@ -468,7 +469,11 @@ def _remove_ld_keys(
                 if not isinstance(v, str):
                     raise ValueError(f"Invalid value found in data: value of type {type(v)} "
                                      f"found associated to a \"@id\" key. Only strings are valid")
-                local_attrs["id"] = context.resolve(v)
+                resolved_id = context.resolve(v)
+                if resolved_id != "":
+                    local_attrs["id"] = resolved_id
+                else:
+                    raise ValueError(f"A space character was found in the identifier (key @id) of the provided dictionary: {v}: please remove all spaces")
             elif k.startswith("@") and k in LD_KEYS.values():
                 local_attrs[k[1:]] = v
             else:

--- a/tests/core/conversions/test_rdf.py
+++ b/tests/core/conversions/test_rdf.py
@@ -112,7 +112,10 @@ class TestJsonLd:
 
     def test_from_jsonld(self, building, model_context, building_jsonld):
         building.context = model_context.document["@context"]
+        a_valid_id = "https://an_id" 
+        building.id = a_valid_id
         payload = building_jsonld(building, "compacted", False, None)
+        payload["@id"] = a_valid_id
         resource = from_jsonld(payload)
         assert resource == building
 
@@ -125,6 +128,10 @@ class TestJsonLd:
         assert "value" not in LD_KEYS.keys()
         assert hasattr(resource_with_atvalue, "status")
         assert resource_with_atvalue.status == Resource.from_json({"type":"xsd:string", "@value":"opened"})
+
+        payload["@id"] = " https://an_id_with_space_id"
+        with pytest.raises(ValueError):
+            from_jsonld(payload) 
 
     def test_as_jsonld(self, building, model_context, building_jsonld, forge):
         building.context = model_context.document["@context"]


### PR DESCRIPTION
rdflib.plugins.shared.jsonld.context.Context.resolve(iri) [return ""](https://github.com/RDFLib/rdflib/blob/f34c476ff099b39fe253430cdc25ebc121837e5e/rdflib/plugins/shared/jsonld/context.py#L323) when iri contains space. This leads to silently replacing an iri with "" in   [_remove_ld_keys](https://github.com/BlueBrain/nexus-forge/blob/a936ef152e82afaa1ca0fc019dc4b3f5f79cecae/kgforge/core/conversions/rdf.py#L471).