### PR TITLE
Fix cyclic dependency between Mapping and KnowledgeGraphForge

### DIFF
--- a/kgforge/core/archetypes/dataset_store.py
+++ b/kgforge/core/archetypes/dataset_store.py
@@ -15,15 +15,13 @@
 from abc import abstractmethod, ABC
 
 from typing import Optional, Union, List, Type, Dict
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.archetypes.read_only_store import ReadOnlyStore
 from kgforge.core.archetypes.resolver import Resolver
-from kgforge.core.archetypes.model import Model
 from kgforge.core.archetypes.mapping import Mapping
 from kgforge.core.archetypes.mapper import Mapper
 from kgforge.core.commons.imports import import_class
 from kgforge.core.conversions.json import as_json, from_json
-from kgforge.core.commons.execution import not_supported
 from kgforge.core.wrappings import Filter
 
 

--- a/kgforge/core/archetypes/read_only_store.py
+++ b/kgforge/core/archetypes/read_only_store.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.archetypes.model import Model
 from kgforge.core.archetypes.resolver import Resolver
 from kgforge.core.commons.attributes import repr_class

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -13,13 +13,14 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Type
 
 import numpy as np
 import yaml
 from pandas import DataFrame
 from rdflib import Graph
 
+from kgforge.core.archetypes import Mapper
 from kgforge.core.resource import Resource
 from kgforge.core.commons.files import load_file_as_byte
 from kgforge.core.archetypes.mapping import Mapping
@@ -44,8 +45,6 @@ from kgforge.core.conversions.rdf import (
 )
 from kgforge.core.reshaping import Reshaper
 from kgforge.core.wrappings.paths import PathsWrapper, wrap_paths, Filter
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
 
 
 class KnowledgeGraphForge:
@@ -548,7 +547,7 @@ class KnowledgeGraphForge:
 
     @catch
     def mapping(
-        self, entity: str, source: str, type: Callable = DictionaryMapping
+        self, entity: str, source: str, type: Type[Mapping] = "DictionaryMapping"
     ) -> Mapping:
         """
         Return a Mapping object of type 'type' for a resource type 'entity' and a source.
@@ -565,7 +564,7 @@ class KnowledgeGraphForge:
         self,
         data: Any,
         mapping: Union[Mapping, List[Mapping]],
-        mapper: Callable = DictionaryMapper,
+        mapper: Type[Mapper] = "DictionaryMapper",
         na: Union[Any, List[Any]] = None,
     ) -> Union[Resource, List[Resource]]:
         """

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -21,12 +21,12 @@ from pandas import DataFrame
 from rdflib import Graph
 
 from kgforge.core.resource import Resource
-from kgforge.core.commons.files import load_file_as_byte
 from kgforge.core.archetypes.mapping import Mapping
 from kgforge.core.archetypes.model import Model
 from kgforge.core.archetypes.resolver import Resolver
 from kgforge.core.archetypes.mapper import Mapper
 from kgforge.core.archetypes.store import Store
+from kgforge.core.commons.files import load_file_as_byte
 from kgforge.core.commons.actions import LazyAction
 from kgforge.core.commons.dictionaries import with_defaults
 from kgforge.core.commons.exceptions import ResolvingError
@@ -45,8 +45,6 @@ from kgforge.core.conversions.rdf import (
 )
 from kgforge.core.reshaping import Reshaper
 from kgforge.core.wrappings.paths import PathsWrapper, wrap_paths, Filter
-from kgforge.specializations.mappers.dictionaries import DictionaryMapper
-from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 
 
 class KnowledgeGraphForge:
@@ -549,7 +547,7 @@ class KnowledgeGraphForge:
 
     @catch
     def mapping(
-        self, entity: str, source: str, type: Type[Mapping] = DictionaryMapping
+        self, entity: str, source: str, type: Type[Mapping] = None
     ) -> Mapping:
         """
         Return a Mapping object of type 'type' for a resource type 'entity' and a source.
@@ -559,6 +557,8 @@ class KnowledgeGraphForge:
         :param type: a Mapping class
         :return: Mapping
         """
+        if type is None:
+            type = self._store.mapping
         return self._model.mapping(entity, source, type)
 
     @catch
@@ -566,7 +566,7 @@ class KnowledgeGraphForge:
         self,
         data: Any,
         mapping: Union[Mapping, List[Mapping]],
-        mapper: Type[Mapper] = DictionaryMapper,
+        mapper: Type[Mapper] = None,
         na: Union[Any, List[Any]] = None,
     ) -> Union[Resource, List[Resource]]:
         """
@@ -579,6 +579,8 @@ class KnowledgeGraphForge:
         :param na: represents missing values
         :return: Union[Resource, List[Resource]]
         """
+        if mapper is None:
+            mapper = self._store.mapper
         return mapper(self).map(data, mapping, na)
 
     # Reshaping User Interface.

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -45,6 +45,8 @@ from kgforge.core.conversions.rdf import (
 )
 from kgforge.core.reshaping import Reshaper
 from kgforge.core.wrappings.paths import PathsWrapper, wrap_paths, Filter
+from kgforge.specializations.mappers import DictionaryMapper
+from kgforge.specializations.mappings import DictionaryMapping
 
 
 class KnowledgeGraphForge:
@@ -547,7 +549,7 @@ class KnowledgeGraphForge:
 
     @catch
     def mapping(
-        self, entity: str, source: str, type: Type[Mapping] = "DictionaryMapping"
+        self, entity: str, source: str, type: Type[Mapping] = DictionaryMapping
     ) -> Mapping:
         """
         Return a Mapping object of type 'type' for a resource type 'entity' and a source.
@@ -564,7 +566,7 @@ class KnowledgeGraphForge:
         self,
         data: Any,
         mapping: Union[Mapping, List[Mapping]],
-        mapper: Type[Mapper] = "DictionaryMapper",
+        mapper: Type[Mapper] = DictionaryMapper,
         na: Union[Any, List[Any]] = None,
     ) -> Union[Resource, List[Resource]]:
         """

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -20,12 +20,12 @@ import yaml
 from pandas import DataFrame
 from rdflib import Graph
 
-from kgforge.core.archetypes import Mapper
 from kgforge.core.resource import Resource
 from kgforge.core.commons.files import load_file_as_byte
 from kgforge.core.archetypes.mapping import Mapping
 from kgforge.core.archetypes.model import Model
 from kgforge.core.archetypes.resolver import Resolver
+from kgforge.core.archetypes.mapper import Mapper
 from kgforge.core.archetypes.store import Store
 from kgforge.core.commons.actions import LazyAction
 from kgforge.core.commons.dictionaries import with_defaults
@@ -45,8 +45,8 @@ from kgforge.core.conversions.rdf import (
 )
 from kgforge.core.reshaping import Reshaper
 from kgforge.core.wrappings.paths import PathsWrapper, wrap_paths, Filter
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 
 
 class KnowledgeGraphForge:

--- a/kgforge/specializations/mappers/__init__.py
+++ b/kgforge/specializations/mappers/__init__.py
@@ -12,4 +12,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
-# from .dictionaries import DictionaryMapper
+from .dictionaries import DictionaryMapper

--- a/kgforge/specializations/mappers/__init__.py
+++ b/kgforge/specializations/mappers/__init__.py
@@ -12,4 +12,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
-from .dictionaries import DictionaryMapper
+# from .dictionaries import DictionaryMapper

--- a/kgforge/specializations/mappings/__init__.py
+++ b/kgforge/specializations/mappings/__init__.py
@@ -12,4 +12,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
-# from .dictionaries import DictionaryMapping
+from .dictionaries import DictionaryMapping

--- a/kgforge/specializations/mappings/__init__.py
+++ b/kgforge/specializations/mappings/__init__.py
@@ -12,4 +12,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
-from .dictionaries import DictionaryMapping
+# from .dictionaries import DictionaryMapping

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -20,7 +20,7 @@ from pyshacl.consts import SH
 from rdflib import URIRef, Literal
 from rdflib.namespace import XSD
 
-from kgforge.core.archetypes import Mapping
+from kgforge.core.archetypes.mapping import Mapping
 from kgforge.core.resource import Resource
 from kgforge.core.archetypes.store import Store
 from kgforge.core.archetypes.model import Model

--- a/kgforge/specializations/resolvers/agent_resolver.py
+++ b/kgforge/specializations/resolvers/agent_resolver.py
@@ -19,8 +19,8 @@ from kgforge.core.archetypes.resolver import _build_resolving_query
 from kgforge.core.commons.execution import not_supported
 from kgforge.core.commons.sparql_query_builder import SPARQLQueryBuilder
 from kgforge.core.commons.strategies import ResolvingStrategy
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 from kgforge.specializations.resolvers.store_service import StoreService
 
 

--- a/kgforge/specializations/resolvers/demo_resolver.py
+++ b/kgforge/specializations/resolvers/demo_resolver.py
@@ -21,8 +21,8 @@ from kgforge.core.archetypes.resolver import Resolver
 from kgforge.core.commons.exceptions import ConfigurationError
 from kgforge.core.commons.execution import not_supported
 from kgforge.core.commons.strategies import ResolvingStrategy
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 
 
 class DemoResolver(Resolver):

--- a/kgforge/specializations/resolvers/entity_linking/entity_linker_elastic.py
+++ b/kgforge/specializations/resolvers/entity_linking/entity_linker_elastic.py
@@ -13,8 +13,8 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 from typing import Callable, Dict, Optional
 
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 from kgforge.specializations.resolvers.entity_linking import EntityLinker
 from kgforge.specializations.resolvers.entity_linking.service.entity_linking_elastic_service import EntityLinkerElasticService
 

--- a/kgforge/specializations/resolvers/entity_linking/service/entity_linking_elastic_service.py
+++ b/kgforge/specializations/resolvers/entity_linking/service/entity_linking_elastic_service.py
@@ -22,8 +22,8 @@ from kgforge.core.archetypes.store import Store
 from kgforge.core.conversions.json import as_json
 from kgforge.core.resource import encode
 from kgforge.core.wrappings import Filter, FilterOperator
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 from kgforge.specializations.resolvers.entity_linking.service.entity_linking_service import (
     EntityLinkerService,
 )

--- a/kgforge/specializations/resolvers/ontology_resolver.py
+++ b/kgforge/specializations/resolvers/ontology_resolver.py
@@ -19,8 +19,8 @@ from kgforge.core.archetypes.resolver import _build_resolving_query
 from kgforge.core.commons.execution import not_supported
 from kgforge.core.commons.sparql_query_builder import SPARQLQueryBuilder
 from kgforge.core.commons.strategies import ResolvingStrategy
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 from kgforge.specializations.resolvers.store_service import StoreService
 
 

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -59,8 +59,8 @@ from kgforge.core.conversions.json import as_json
 from kgforge.core.conversions.rdf import as_jsonld
 from kgforge.core.wrappings.dict import DictWrapper
 from kgforge.core.wrappings.paths import Filter, create_filters_from_dict
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 from kgforge.specializations.stores.nexus.service import BatchAction, Service, _error_message
 
 

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -16,7 +16,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Type, Tuple, Any
 from uuid import uuid4
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.archetypes.resolver import Resolver
 from kgforge.core.archetypes.store import Store
 from kgforge.core.archetypes.mapper import Mapper

--- a/kgforge/specializations/stores/sparql/sparql_service.py
+++ b/kgforge/specializations/stores/sparql/sparql_service.py
@@ -15,7 +15,7 @@
 import copy
 from typing import Dict, List, Optional, Union, Tuple
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.commons.context import Context
 from kgforge.core.wrappings.dict import wrap_dict
 

--- a/kgforge/specializations/stores/sparql_store.py
+++ b/kgforge/specializations/stores/sparql_store.py
@@ -15,13 +15,13 @@
 import requests
 from typing import Dict, List, Optional, Union, Any, Type, Tuple
 
-from kgforge.core import Resource
-from kgforge.core.archetypes import Mapper
+from kgforge.core.resource import Resource
+from kgforge.core.archetypes.mapper import Mapper
 from kgforge.core.archetypes.resolver import Resolver
 from kgforge.core.archetypes.model import Model
 from kgforge.core.archetypes.dataset_store import DatasetStore
 from kgforge.core.commons import Context
-from kgforge.specializations.mappers import DictionaryMapper
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
 from kgforge.specializations.stores.sparql.sparql_service import SPARQLService
 from kgforge.core.wrappings.paths import create_filters_from_dict, Filter
 from kgforge.core.wrappings.dict import DictWrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ from utils import full_path_relative_to_root
 import pytest
 from pytest_bdd import given, parsers, then, when
 
-from kgforge.core import Resource, KnowledgeGraphForge
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
 from kgforge.core.commons.actions import Action
 from kgforge.core.commons.context import Context
 from kgforge.core.conversions.rdf import _merge_jsonld, Form

--- a/tests/core/archetypes/test_read_only_store.py
+++ b/tests/core/archetypes/test_read_only_store.py
@@ -15,7 +15,8 @@
 # Placeholder for the test suite for actions.
 import pytest
 
-from kgforge.core import Resource, KnowledgeGraphForge
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
 from kgforge.core.commons.exceptions import DownloadingError
 
 

--- a/tests/core/archetypes/test_store.py
+++ b/tests/core/archetypes/test_store.py
@@ -15,7 +15,8 @@
 # Placeholder for the test suite for actions.
 import pytest
 
-from kgforge.core import Resource, KnowledgeGraphForge
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
 from kgforge.specializations.resources import Dataset
 from kgforge.core.wrappings.dict import wrap_dict
 import json

--- a/tests/core/commons/test_actions.py
+++ b/tests/core/commons/test_actions.py
@@ -14,7 +14,7 @@
 
 # Placeholder for the test suite for actions.
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.commons.actions import LazyAction, collect_lazy_actions, execute_lazy_actions
 
 

--- a/tests/core/conversions/conftest.py
+++ b/tests/core/conversions/conftest.py
@@ -18,7 +18,8 @@ from uuid import uuid4
 from urllib.parse import urljoin
 from urllib.request import pathname2url
 
-from kgforge.core import KnowledgeGraphForge, Resource
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
 from kgforge.core.commons.context import Context
 from kgforge.core.conversions.rdf import _merge_jsonld
 from kgforge.core.wrappings.dict import wrap_dict

--- a/tests/core/conversions/test_dataframe.py
+++ b/tests/core/conversions/test_dataframe.py
@@ -19,7 +19,7 @@ from pandas import DataFrame
 
 # Test suite for conversion of resource to / from Pandas DataFrame.
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 
 
 @pytest.fixture

--- a/tests/core/conversions/test_rdf.py
+++ b/tests/core/conversions/test_rdf.py
@@ -24,7 +24,7 @@ import pytest
 from rdflib import Graph, BNode, term
 from rdflib.namespace import RDF, Namespace
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.commons.exceptions import NotSupportedError
 from kgforge.core.conversions.rdf import _merge_jsonld, _resolve_iri, from_jsonld, as_jsonld, Form, as_graph, from_graph, LD_KEYS
 

--- a/tests/core/test_forge.py
+++ b/tests/core/test_forge.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from kgforge.core import KnowledgeGraphForge
+from kgforge.core.forge import KnowledgeGraphForge
 
 SCOPE = "terms"
 MODEL = "DemoModel"

--- a/tests/core/test_reshaping.py
+++ b/tests/core/test_reshaping.py
@@ -14,7 +14,8 @@
 
 # Placeholder for the test suite for reshaping.
 import pytest
-from kgforge.core import Resource, KnowledgeGraphForge
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
 from kgforge.core.reshaping import collect_values, Reshaper
 
 

--- a/tests/core/test_resource.py
+++ b/tests/core/test_resource.py
@@ -15,7 +15,7 @@
 import pytest
 from pytest_bdd import given, scenarios, then, when
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 
 # TODO To be port to the generic parameterizable test suite for resources in test_resources.py.
 #  DKE-135.

--- a/tests/specializations/mappers/test_mappers.py
+++ b/tests/specializations/mappers/test_mappers.py
@@ -17,9 +17,10 @@
 import pytest
 from contextlib import nullcontext as does_not_raise
 
-from kgforge.core import KnowledgeGraphForge, Resource
-from kgforge.specializations.mappers import DictionaryMapper
-from kgforge.specializations.mappings import DictionaryMapping
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
+from kgforge.specializations.mappers.dictionaries import DictionaryMapper
+from kgforge.specializations.mappings.dictionaries import DictionaryMapping
 
 
 @pytest.fixture

--- a/tests/specializations/models/test_rdf_model.py
+++ b/tests/specializations/models/test_rdf_model.py
@@ -14,7 +14,7 @@
 import json
 import pytest
 
-from kgforge.core import Resource
+from kgforge.core.resource import Resource
 from kgforge.core.commons.exceptions import ValidationError
 from kgforge.specializations.models import RdfModel
 from tests.specializations.models.data import *

--- a/tests/specializations/resources/test_datasets.py
+++ b/tests/specializations/resources/test_datasets.py
@@ -15,7 +15,8 @@
 # Placeholder for the generic parameterizable test suite for resources.
 from typing import List
 
-from kgforge.core import KnowledgeGraphForge, Resource
+from kgforge.core.resource import Resource
+from kgforge.core.forge import KnowledgeGraphForge
 from kgforge.specializations.resources import Dataset
 
 

--- a/tests/specializations/stores/test_bluebrain_nexus.py
+++ b/tests/specializations/stores/test_bluebrain_nexus.py
@@ -22,8 +22,8 @@ import nexussdk
 import pytest
 from typing import Callable, Union, List
 
-from kgforge.core import Resource
-from kgforge.core.archetypes import Store
+from kgforge.core.resource import Resource
+from kgforge.core.archetypes.store import Store
 from kgforge.core.commons.context import Context
 from kgforge.core.conversions.rdf import _merge_jsonld
 from kgforge.core.wrappings.dict import wrap_dict


### PR DESCRIPTION
KnowledgeGraphForge picks specializations of mappings/mappers as default types of Mapping/Mapper to use. There's a cyclic dependency error if one tries to import both KnowledgeGraphForge and DictionaryMapping. 

This removes the imports of DictionaryMapping and DictionaryMapper in KnowledgeGraphForge: 
I think having core import specializations is not a good practice, and I've replaced the default value that KnowledgeGraphForge with the mapping and mapper defined by the store it holds. It could be that this makes no sense, if ever the intended usage of these mappings/mappers is different. 

I've also made the specializations file import the classes directly from the files they were defined, and not the packages they are contained in. I feel like it's more of a user interface feature to have the ability to import from packages. It could be argued that specializations should be defined by users and so they should also import the same way...