### PR TITLE
Pass view when forge.sparql, forge.elastic, forge.search call

### DIFF
--- a/examples/notebooks/getting-started/04 - Querying.ipynb
+++ b/examples/notebooks/getting-started/04 - Querying.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 141,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:20.068658Z",
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 145,
    "metadata": {},
    "outputs": [
     {
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 147,
    "metadata": {},
    "outputs": [
     {
@@ -128,7 +128,7 @@
        "True"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 147,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 148,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 149,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 150,
    "metadata": {},
    "outputs": [
     {
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 152,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 153,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.317601Z",
@@ -246,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 154,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.332678Z",
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 155,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.370051Z",
@@ -274,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 157,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.379911Z",
@@ -297,7 +297,7 @@
        "True"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 157,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 158,
    "metadata": {},
    "outputs": [
     {
@@ -317,7 +317,7 @@
        "True"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 158,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 159,
    "metadata": {},
    "outputs": [
     {
@@ -337,7 +337,7 @@
        "True"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 159,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 160,
    "metadata": {},
    "outputs": [
     {
@@ -379,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,28 +388,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 162,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/5eb29fff-931d-454e-b836-10ca68578899',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/b6a3d43a-bf8f-4e4a-bdd5-49a67fb34456',\n",
        " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
-       " '_createdAt': '2024-02-02T09:19:23.366Z',\n",
+       " '_createdAt': '2024-02-02T09:59:27.956Z',\n",
        " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
        " '_deprecated': False,\n",
-       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/incoming',\n",
-       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/outgoing',\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2Fb6a3d43a-bf8f-4e4a-bdd5-49a67fb34456/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2Fb6a3d43a-bf8f-4e4a-bdd5-49a67fb34456/outgoing',\n",
        " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
        " '_rev': 3,\n",
        " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
-       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899',\n",
-       " '_updatedAt': '2024-02-02T09:19:23.719Z',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2Fb6a3d43a-bf8f-4e4a-bdd5-49a67fb34456',\n",
+       " '_updatedAt': '2024-02-02T09:59:28.486Z',\n",
        " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 162,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 163,
    "metadata": {},
    "outputs": [
     {
@@ -429,7 +429,7 @@
        "Action(error=None, message=None, operation='retrieve', succeeded=True)"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 163,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 164,
    "metadata": {},
    "outputs": [
     {
@@ -449,7 +449,7 @@
        "True"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 164,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -463,22 +463,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieving using the resorce url\n",
+    "### Retrieving using the resource url\n",
     "One can also use the value of `_self` from ._stote_metadata to retrieve a resource"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 165,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import copy"
+    "import copy\n",
+    "import string\n",
+    "import random"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,16 +489,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 167,
    "metadata": {},
    "outputs": [],
    "source": [
-    "other_resource.id = \"https://myincreadibleid-987654321\""
+    "other_resource.id = f\"https://my-incredible-id-{''.join(random.choices(string.digits, k=5))}\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 168,
    "metadata": {},
    "outputs": [
     {
@@ -504,8 +506,7 @@
      "output_type": "stream",
      "text": [
       "<action> _register_one\n",
-      "<succeeded> False\n",
-      "<error> RegistrationError: resource 'https://myincreadibleid-987654321' already exists in project 'github-users/ssssarah'\n"
+      "<succeeded> True\n"
      ]
     }
    ],
@@ -515,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 169,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,16 +543,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 171,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 171,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -571,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 172,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,20 +581,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 173,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/5eb29fff-931d-454e-b836-10ca68578899',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/b6a3d43a-bf8f-4e4a-bdd5-49a67fb34456',\n",
        " 'type': 'Person',\n",
        " 'award': 'Nobel',\n",
        " 'email': ['jane.doe@epfl.ch', 'jane.doe@example.org'],\n",
        " 'name': 'Jane Doe'}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 173,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -604,28 +605,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 174,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/5eb29fff-931d-454e-b836-10ca68578899',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/b6a3d43a-bf8f-4e4a-bdd5-49a67fb34456',\n",
        " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
-       " '_createdAt': '2024-02-02T09:19:23.366Z',\n",
+       " '_createdAt': '2024-02-02T09:59:27.956Z',\n",
        " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
        " '_deprecated': False,\n",
-       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/incoming',\n",
-       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/outgoing',\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2Fb6a3d43a-bf8f-4e4a-bdd5-49a67fb34456/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2Fb6a3d43a-bf8f-4e4a-bdd5-49a67fb34456/outgoing',\n",
        " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
        " '_rev': 3,\n",
        " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
-       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899',\n",
-       " '_updatedAt': '2024-02-02T09:19:23.719Z',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2Fb6a3d43a-bf8f-4e4a-bdd5-49a67fb34456',\n",
+       " '_updatedAt': '2024-02-02T09:59:28.486Z',\n",
        " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 174,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -636,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 175,
    "metadata": {},
    "outputs": [
     {
@@ -645,7 +646,7 @@
        "Action(error=None, message=None, operation='retrieve', succeeded=True)"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 175,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -656,7 +657,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 176,
    "metadata": {},
    "outputs": [
     {
@@ -665,7 +666,7 @@
        "True"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 176,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -684,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [
     {
@@ -703,7 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [
     {
@@ -712,7 +713,7 @@
        "True"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 178,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -739,7 +740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +760,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 181,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 182,
    "metadata": {},
    "outputs": [
     {
@@ -787,13 +788,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 183,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/31a7f009-e803-47f8-ac47-87237a4c8d9c',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/f0689ed3-29b4-4462-867c-73e53197ec37',\n",
        " 'type': 'Dataset',\n",
        " 'contribution': [{'type': 'Contribution',\n",
        "   'agent': {'type': 'Person', 'name': 'Jane Doe'}},\n",
@@ -804,14 +805,14 @@
        "    'type': 'DiskStorage',\n",
        "    '_rev': 1}},\n",
        "  'contentSize': {'unitCode': 'bytes', 'value': 477},\n",
-       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F948556c2-cc72-497a-9e17-9398c288137b',\n",
+       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F69b4201d-bc75-4b8e-be85-0817214c2c39',\n",
        "  'digest': {'algorithm': 'SHA-256',\n",
        "   'value': '789aa07948683fe036ac29811814a826b703b562f7d168eb70dee1fabde26859'},\n",
        "  'encodingFormat': 'text/tab-separated-values',\n",
        "  'name': 'associations.tsv'}}"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 183,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -840,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -873,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 185,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 186,
    "metadata": {},
    "outputs": [
     {
@@ -891,7 +892,7 @@
        "list"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 186,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -902,7 +903,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 187,
    "metadata": {},
    "outputs": [
     {
@@ -911,7 +912,7 @@
        "3"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 187,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -922,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 188,
    "metadata": {},
    "outputs": [
     {
@@ -994,7 +995,7 @@
        "2  Jane Doe                                       NaN  "
       ]
      },
-     "execution_count": 48,
+     "execution_count": 188,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1005,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 189,
    "metadata": {},
    "outputs": [
     {
@@ -1175,7 +1176,7 @@
        "2                                       NaN  "
       ]
      },
-     "execution_count": 49,
+     "execution_count": 189,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1186,7 +1187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [
     {
@@ -1195,7 +1196,7 @@
        "False"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 190,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1223,7 +1224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 192,
    "metadata": {},
    "outputs": [
     {
@@ -1242,7 +1243,7 @@
        "3"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 192,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1253,7 +1254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 193,
    "metadata": {
     "scrolled": true
    },
@@ -1281,6 +1282,7 @@
        "      <th></th>\n",
        "      <th>id</th>\n",
        "      <th>type</th>\n",
+       "      <th>contribution</th>\n",
        "      <th>distribution.type</th>\n",
        "      <th>distribution.atLocation.type</th>\n",
        "      <th>distribution.atLocation.store.id</th>\n",
@@ -1301,6 +1303,7 @@
        "      <th>0</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Dataset</td>\n",
+       "      <td>[{'type': 'Contribution', 'agent': {'type': 'P...</td>\n",
        "      <td>DataDownload</td>\n",
        "      <td>Location</td>\n",
        "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
@@ -1313,12 +1316,13 @@
        "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
        "      <td>text/tab-separated-values</td>\n",
        "      <td>associations.tsv</td>\n",
-       "      <td>Interesting Persons</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Dataset</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>DataDownload</td>\n",
        "      <td>Location</td>\n",
        "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
@@ -1337,6 +1341,7 @@
        "      <th>2</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Dataset</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>DataDownload</td>\n",
        "      <td>Location</td>\n",
        "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
@@ -1361,10 +1366,15 @@
        "1  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
        "2  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
        "\n",
-       "  distribution.type distribution.atLocation.type  \\\n",
-       "0      DataDownload                     Location   \n",
-       "1      DataDownload                     Location   \n",
-       "2      DataDownload                     Location   \n",
+       "                                        contribution distribution.type  \\\n",
+       "0  [{'type': 'Contribution', 'agent': {'type': 'P...      DataDownload   \n",
+       "1                                                NaN      DataDownload   \n",
+       "2                                                NaN      DataDownload   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "1                     Location   \n",
+       "2                     Location   \n",
        "\n",
        "                    distribution.atLocation.store.id  \\\n",
        "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
@@ -1397,12 +1407,12 @@
        "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
        "\n",
        "  distribution.encodingFormat distribution.name                 name  \n",
-       "0   text/tab-separated-values  associations.tsv  Interesting Persons  \n",
+       "0   text/tab-separated-values  associations.tsv                  NaN  \n",
        "1   text/tab-separated-values  associations.tsv  Interesting Persons  \n",
        "2   text/tab-separated-values  associations.tsv  Interesting Persons  "
       ]
      },
-     "execution_count": 53,
+     "execution_count": 193,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1428,7 +1438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 194,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1444,7 +1454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 195,
    "metadata": {},
    "outputs": [
     {
@@ -1453,7 +1463,7 @@
        "list"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 195,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1464,7 +1474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 196,
    "metadata": {},
    "outputs": [
     {
@@ -1473,7 +1483,7 @@
        "0"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 196,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1484,7 +1494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 197,
    "metadata": {},
    "outputs": [
     {
@@ -1521,7 +1531,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 197,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1548,7 +1558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 198,
    "metadata": {},
    "outputs": [
     {
@@ -1562,7 +1572,7 @@
        " '__ge__ (GREATER_OR_Equal_Than)']"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 198,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1573,7 +1583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1588,7 +1598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 200,
    "metadata": {},
    "outputs": [
     {
@@ -1597,7 +1607,7 @@
        "list"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 200,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1608,7 +1618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 201,
    "metadata": {},
    "outputs": [
     {
@@ -1617,7 +1627,7 @@
        "3"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 201,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1628,7 +1638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 202,
    "metadata": {},
    "outputs": [
     {
@@ -1654,6 +1664,7 @@
        "      <th></th>\n",
        "      <th>id</th>\n",
        "      <th>type</th>\n",
+       "      <th>contribution</th>\n",
        "      <th>distribution.type</th>\n",
        "      <th>distribution.atLocation.type</th>\n",
        "      <th>distribution.atLocation.store.id</th>\n",
@@ -1661,9 +1672,7 @@
        "      <th>distribution.atLocation.store._rev</th>\n",
        "      <th>distribution.contentSize.unitCode</th>\n",
        "      <th>distribution.contentSize.value</th>\n",
-       "      <th>distribution.contentUrl</th>\n",
        "      <th>...</th>\n",
-       "      <th>_createdBy</th>\n",
        "      <th>_deprecated</th>\n",
        "      <th>_incoming</th>\n",
        "      <th>_outgoing</th>\n",
@@ -1673,6 +1682,7 @@
        "      <th>_self</th>\n",
        "      <th>_updatedAt</th>\n",
        "      <th>_updatedBy</th>\n",
+       "      <th>name</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1680,6 +1690,7 @@
        "      <th>0</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Dataset</td>\n",
+       "      <td>[{'type': 'Contribution', 'agent': {'type': 'P...</td>\n",
        "      <td>DataDownload</td>\n",
        "      <td>Location</td>\n",
        "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
@@ -1687,9 +1698,31 @@
        "      <td>1</td>\n",
        "      <td>bytes</td>\n",
        "      <td>477</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
        "      <td>...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-02T09:47:31.662Z</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>...</td>\n",
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
@@ -1699,11 +1732,13 @@
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>2022-12-07T16:07:59.200Z</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>Interesting Persons</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>2</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Dataset</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>DataDownload</td>\n",
        "      <td>Location</td>\n",
        "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
@@ -1711,9 +1746,7 @@
        "      <td>1</td>\n",
        "      <td>bytes</td>\n",
        "      <td>477</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
        "      <td>...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
@@ -1723,34 +1756,11 @@
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>2022-12-08T09:46:09.139Z</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Dataset</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>477</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>2022-12-08T12:22:35.660Z</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>Interesting Persons</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>3 rows × 27 columns</p>\n",
+       "<p>3 rows × 28 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1759,10 +1769,15 @@
        "1  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
        "2  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
        "\n",
-       "  distribution.type distribution.atLocation.type  \\\n",
-       "0      DataDownload                     Location   \n",
-       "1      DataDownload                     Location   \n",
-       "2      DataDownload                     Location   \n",
+       "                                        contribution distribution.type  \\\n",
+       "0  [{'type': 'Contribution', 'agent': {'type': 'P...      DataDownload   \n",
+       "1                                                NaN      DataDownload   \n",
+       "2                                                NaN      DataDownload   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "1                     Location   \n",
+       "2                     Location   \n",
        "\n",
        "                    distribution.atLocation.store.id  \\\n",
        "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
@@ -1774,25 +1789,15 @@
        "1                        DiskStorage                                   1   \n",
        "2                        DiskStorage                                   1   \n",
        "\n",
-       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
-       "0                             bytes                             477   \n",
-       "1                             bytes                             477   \n",
-       "2                             bytes                             477   \n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  ...  \\\n",
+       "0                             bytes                             477  ...   \n",
+       "1                             bytes                             477  ...   \n",
+       "2                             bytes                             477  ...   \n",
        "\n",
-       "                             distribution.contentUrl  ...  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/files/git...  ...   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/files/git...  ...   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/files/git...  ...   \n",
-       "\n",
-       "                                          _createdBy _deprecated  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
-       "\n",
-       "                                           _incoming  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "  _deprecated                                          _incoming  \\\n",
+       "0       False  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1       False  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2       False  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
        "                                           _outgoing  \\\n",
        "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
@@ -1814,15 +1819,20 @@
        "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                 _updatedAt                                         _updatedBy  \n",
-       "0  2022-12-07T16:07:59.200Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
-       "1  2022-12-08T09:46:09.139Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
-       "2  2022-12-08T12:22:35.660Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
+       "                 _updatedAt  \\\n",
+       "0  2024-02-02T09:47:31.662Z   \n",
+       "1  2022-12-07T16:07:59.200Z   \n",
+       "2  2022-12-08T09:46:09.139Z   \n",
        "\n",
-       "[3 rows x 27 columns]"
+       "                                          _updatedBy                 name  \n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...                  NaN  \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...  Interesting Persons  \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...  Interesting Persons  \n",
+       "\n",
+       "[3 rows x 28 columns]"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 202,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1856,7 +1866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 203,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,7 +1877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 204,
    "metadata": {},
    "outputs": [
     {
@@ -1876,7 +1886,7 @@
        "list"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 204,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1887,7 +1897,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 205,
    "metadata": {},
    "outputs": [
     {
@@ -1896,7 +1906,7 @@
        "3"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 205,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1907,7 +1917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 206,
    "metadata": {},
    "outputs": [
     {
@@ -2077,7 +2087,7 @@
        "2                                       NaN  "
       ]
      },
-     "execution_count": 66,
+     "execution_count": 206,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2096,7 +2106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 207,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2109,7 +2119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 208,
    "metadata": {},
    "outputs": [
     {
@@ -2118,7 +2128,7 @@
        "list"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 208,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2129,7 +2139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 209,
    "metadata": {},
    "outputs": [
     {
@@ -2138,7 +2148,7 @@
        "3"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 209,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2149,7 +2159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 210,
    "metadata": {},
    "outputs": [
     {
@@ -2204,7 +2214,7 @@
        "2  https://sandbox.bluebrainnexus.io/v1/resources...  http://schema.org/Person"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 210,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2215,7 +2225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 211,
    "metadata": {},
    "outputs": [
     {
@@ -2224,7 +2234,7 @@
        "False"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 211,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2236,7 +2246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 212,
    "metadata": {},
    "outputs": [
     {
@@ -2245,7 +2255,7 @@
        "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/e01663b6-604b-42db-b958-da9fbc1baca2'"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 212,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2256,7 +2266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 213,
    "metadata": {},
    "outputs": [
     {
@@ -2265,7 +2275,7 @@
        "'http://schema.org/Person'"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 213,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2290,7 +2300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 214,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2328,16 +2338,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 215,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/a9611b3e-3c85-487b-befc-415e347dd9a1'"
+       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/6562a440-386a-4128-9fe7-f42f0c9b6f38'"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 215,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2356,32 +2366,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 281,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'http://schema.org/Dataset'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n",
-      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'http://schema.org/Person'}}, {'term': {'_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n"
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'Dataset'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n",
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'Person'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(0, 0)"
+       "(0, 100)"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 281,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result_1 = forge.search({\"@type\": \"http://schema.org/Dataset\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True)\n",
+    "result_1 = forge.search({\"@type\": \"Dataset\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True)\n",
     "\n",
-    "result_2 =  forge.search({\"@type\": \"http://schema.org/Person\"}, search_endpoint='elastic', view=view_id, debug=True)\n",
+    "result_2 =  forge.search({\"@type\": \"Person\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True)\n",
     "\n",
     "len(result_1), len(result_2)"
    ]
@@ -2404,7 +2414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 217,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2413,34 +2423,235 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 218,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 218,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 219,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 219,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 220,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>agent.type</th>\n",
+       "      <th>agent.gender.id</th>\n",
+       "      <th>agent.gender.type</th>\n",
+       "      <th>agent.gender.label</th>\n",
+       "      <th>agent.name</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000383</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>female</td>\n",
+       "      <td>Marie Curie</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>46.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>marie_curie.txt</td>\n",
+       "      <td>Curie Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000384</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>male</td>\n",
+       "      <td>Albert Einstein</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>albert_einstein.txt</td>\n",
+       "      <td>Einstein Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id         type agent.type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "\n",
+       "                               agent.gender.id      agent.gender.type  \\\n",
+       "0  http://purl.obolibrary.org/obo/PATO_0000383  LabeledOntologyEntity   \n",
+       "1  http://purl.obolibrary.org/obo/PATO_0000384  LabeledOntologyEntity   \n",
+       "2                                          NaN                    NaN   \n",
+       "\n",
+       "  agent.gender.label       agent.name distribution.type  \\\n",
+       "0             female      Marie Curie      DataDownload   \n",
+       "1               male  Albert Einstein      DataDownload   \n",
+       "2                NaN         Jane Doe               NaN   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "1                     Location   \n",
+       "2                          NaN   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                 1.0   \n",
+       "1                        DiskStorage                                 1.0   \n",
+       "2                                NaN                                 NaN   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                             bytes                            46.0   \n",
+       "1                             bytes                            50.0   \n",
+       "2                               NaN                             NaN   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                       SHA-256   \n",
+       "1                       SHA-256   \n",
+       "2                           NaN   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0  e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...   \n",
+       "1  91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.encodingFormat    distribution.name                  name  \n",
+       "0                  text/plain      marie_curie.txt     Curie Association  \n",
+       "1                  text/plain  albert_einstein.txt  Einstein Association  \n",
+       "2                         NaN                  NaN                   NaN  "
+      ]
+     },
+     "execution_count": 220,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2450,27 +2661,88 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 222,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 222,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 223,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 223,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 224,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 224,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2486,7 +2758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2495,27 +2767,228 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 226,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 226,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 227,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 227,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 228,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>agent.type</th>\n",
+       "      <th>agent.gender.id</th>\n",
+       "      <th>agent.gender.type</th>\n",
+       "      <th>agent.gender.label</th>\n",
+       "      <th>agent.name</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000383</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>female</td>\n",
+       "      <td>Marie Curie</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>46.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>marie_curie.txt</td>\n",
+       "      <td>Curie Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000384</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>male</td>\n",
+       "      <td>Albert Einstein</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>albert_einstein.txt</td>\n",
+       "      <td>Einstein Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id         type agent.type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "\n",
+       "                               agent.gender.id      agent.gender.type  \\\n",
+       "0  http://purl.obolibrary.org/obo/PATO_0000383  LabeledOntologyEntity   \n",
+       "1  http://purl.obolibrary.org/obo/PATO_0000384  LabeledOntologyEntity   \n",
+       "2                                          NaN                    NaN   \n",
+       "\n",
+       "  agent.gender.label       agent.name distribution.type  \\\n",
+       "0             female      Marie Curie      DataDownload   \n",
+       "1               male  Albert Einstein      DataDownload   \n",
+       "2                NaN         Jane Doe               NaN   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "1                     Location   \n",
+       "2                          NaN   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                 1.0   \n",
+       "1                        DiskStorage                                 1.0   \n",
+       "2                                NaN                                 NaN   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                             bytes                            46.0   \n",
+       "1                             bytes                            50.0   \n",
+       "2                               NaN                             NaN   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                       SHA-256   \n",
+       "1                       SHA-256   \n",
+       "2                           NaN   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0  e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...   \n",
+       "1  91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.encodingFormat    distribution.name                  name  \n",
+       "0                  text/plain      marie_curie.txt     Curie Association  \n",
+       "1                  text/plain  albert_einstein.txt  Einstein Association  \n",
+       "2                         NaN                  NaN                   NaN  "
+      ]
+     },
+     "execution_count": 228,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2552,7 +3025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2562,7 +3035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 230,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2572,7 +3045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 231,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2581,20 +3054,162 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 232,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(association)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 233,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    id: \"\"\n",
+      "    type:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "    }\n",
+      "    annotation:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: Annotation\n",
+      "        hasBody:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            type:\n",
+      "            {\n",
+      "                id: \"\"\n",
+      "            }\n",
+      "            label: \"\"\n",
+      "            note: \"\"\n",
+      "        }\n",
+      "        hasTarget:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            type: AnnotationTarget\n",
+      "        }\n",
+      "        note: \"\"\n",
+      "    }\n",
+      "    brainLocation:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: BrainLocation\n",
+      "        atlasSpatialReferenceSystem:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            type: AtlasSpatialReferenceSystem\n",
+      "        }\n",
+      "        brainRegion:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            label: \"\"\n",
+      "        }\n",
+      "        coordinatesInBrainAtlas:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            valueX: 0.0\n",
+      "            valueY: 0.0\n",
+      "            valueZ: 0.0\n",
+      "        }\n",
+      "        coordinatesInSlice:\n",
+      "        {\n",
+      "            spatialReferenceSystem:\n",
+      "            {\n",
+      "                id: \"\"\n",
+      "                type: SpatialReferenceSystem\n",
+      "            }\n",
+      "            valueX: 0.0\n",
+      "            valueY: 0.0\n",
+      "            valueZ: 0.0\n",
+      "        }\n",
+      "        distanceToBoundary:\n",
+      "        {\n",
+      "            boundary:\n",
+      "            {\n",
+      "                id: \"\"\n",
+      "                label: \"\"\n",
+      "            }\n",
+      "            distance:\n",
+      "            {\n",
+      "                unitCode: \"\"\n",
+      "                value:\n",
+      "                [\n",
+      "                    0.0\n",
+      "                    0\n",
+      "                ]\n",
+      "            }\n",
+      "        }\n",
+      "        layer:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            label: \"\"\n",
+      "        }\n",
+      "        longitudinalAxis:\n",
+      "        [\n",
+      "            Dorsal\n",
+      "            Ventral\n",
+      "        ]\n",
+      "        positionInLayer:\n",
+      "        [\n",
+      "            Deep\n",
+      "            Superficial\n",
+      "        ]\n",
+      "    }\n",
+      "    contribution:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "    }\n",
+      "    distribution:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: DataDownload\n",
+      "        contentSize:\n",
+      "        {\n",
+      "            unitCode: \"\"\n",
+      "            value: \"\"\n",
+      "        }\n",
+      "        digest:\n",
+      "        {\n",
+      "            algorithm: \"\"\n",
+      "            value: \"\"\n",
+      "        }\n",
+      "        encodingFormat: \"\"\n",
+      "        license: \"\"\n",
+      "        name: \"\"\n",
+      "    }\n",
+      "    objectOfStudy:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: ObjectOfStudy\n",
+      "    }\n",
+      "    releaseDate: 9999-12-31T00:00:00\n",
+      "    subject:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: Subject\n",
+      "    }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "forge.template(\"Dataset\") # Templates help know which property to use when writing a query to serach for a given type"
    ]
@@ -2611,7 +3226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 234,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2627,7 +3242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 235,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2636,36 +3251,131 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 236,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 236,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 237,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 237,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 238,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    id: https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/f0689ed3-29b4-4462-867c-73e53197ec37\n",
+      "    contributor: t3661\n",
+      "    name: Jane Doe\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 239,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>contributor</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>t3661</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>t3662</td>\n",
+       "      <td>John Smith</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>t1771</td>\n",
+       "      <td>John Smith</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id contributor        name\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...       t3661    Jane Doe\n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...       t3662  John Smith\n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...       t1771  John Smith"
+      ]
+     },
+     "execution_count": 239,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2680,9 +3390,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 240,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "   PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "   PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "   PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "   PREFIX nsg: <https://neuroshapes.org/>\n",
+      "   PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "   PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "   PREFIX schema: <http://schema.org/>\n",
+      "   PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "   PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "   PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "   PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "   PREFIX : <https://neuroshapes.org/>\n",
+      "   \n",
+      "       SELECT ?id ?name ?contributor\n",
+      "       WHERE {\n",
+      "           ?id a schema:Dataset ;\n",
+      "           nsg:contribution/prov:agent ?contributor.\n",
+      "           ?contributor schema:name ?name.\n",
+      "       }\n",
+      "     LIMIT 3\n"
+     ]
+    }
+   ],
    "source": [
     "resources = forge.sparql(query, limit=3, debug=True)"
    ]
@@ -2699,7 +3442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 241,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2735,9 +3478,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 242,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   \n",
+      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "      PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "      PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "      PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "      PREFIX nsg: <https://neuroshapes.org/>\n",
+      "      PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "      PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "      PREFIX schema: <http://schema.org/>\n",
+      "      PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "      PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "      PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "      PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "      PREFIX : <https://neuroshapes.org/>\n",
+      "      SELECT ?id ?name\n",
+      "      WHERE {\n",
+      "          ?id a schema:Dataset ;\n",
+      "          nsg:contribution/prov:agent ?contributor.\n",
+      "          ?contributor schema:name ?name.\n",
+      "      }\n",
+      "      ORDER BY ?id\n",
+      "      LIMIT 3\n",
+      "      OFFSET 1\n"
+     ]
+    }
+   ],
    "source": [
     "# it is recommended to set 'rewrite' to 'False' to prevent the sparql query rewriting when a syntactically correct SPARQL query is provided.\n",
     "resources = forge.sparql(query, rewrite=False, limit=3, offset=1, debug=True) "
@@ -2745,36 +3523,126 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 243,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 243,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 244,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 244,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 245,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "kgforge.core.resource.Resource"
+      ]
+     },
+     "execution_count": 245,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 246,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>John Smith</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id        name\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...    Jane Doe\n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  John Smith\n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...    Jane Doe"
+      ]
+     },
+     "execution_count": 246,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2797,7 +3665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 247,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2831,9 +3699,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 248,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   \n",
+      "      PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "      PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "      PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "      PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "      PREFIX nsg: <https://neuroshapes.org/>\n",
+      "      PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "      PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "      PREFIX schema: <http://schema.org/>\n",
+      "      PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "      PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "      PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "      PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "      PREFIX : <https://neuroshapes.org/>\n",
+      "      SELECT ?id ?name\n",
+      "      WHERE {\n",
+      "          ?id a schema:Dataset ;\n",
+      "          nsg:contribution/prov:agent ?contributor.\n",
+      "          ?contributor schema:name ?name.\n",
+      "      }\n",
+      "      ORDER BY ?id\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "resources = forge.sparql(query_without_limit, rewrite=False, limit=None, offset=None, debug=True)"
@@ -2841,9 +3742,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 249,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "70"
+      ]
+     },
+     "execution_count": 249,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
@@ -2858,7 +3770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2874,18 +3786,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 251,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "   PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "   PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "   PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "   PREFIX nsg: <https://neuroshapes.org/>\n",
+      "   PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "   PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "   PREFIX schema: <http://schema.org/>\n",
+      "   PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "   PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "   PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "   PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "   PREFIX : <https://neuroshapes.org/>\n",
+      "   \n",
+      "       SELECT ?id ?name ?contributor\n",
+      "       WHERE {\n",
+      "           ?id a schema:Dataset ;\n",
+      "           nsg:contribution/prov:agent ?contributor.\n",
+      "           ?contributor schema:name ?name.\n",
+      "       }\n"
+     ]
+    }
+   ],
    "source": [
     "resources = forge.sparql(query_without_context, limit=None, debug=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 252,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "70"
+      ]
+     },
+     "execution_count": 252,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
@@ -2910,7 +3865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 253,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2920,7 +3875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 254,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2930,7 +3885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 255,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2939,9 +3894,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 256,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(association)"
    ]
@@ -2956,7 +3920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 257,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2979,7 +3943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 258,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2989,36 +3953,126 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 259,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 259,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 260,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 260,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 261,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "kgforge.core.resource.Resource"
+      ]
+     },
+     "execution_count": 261,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 262,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
+       "      <td>AA1543</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
+       "      <td>AA1542</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
+       "      <td>AA1544</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id    name\n",
+       "0  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1543\n",
+       "1  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1542\n",
+       "2  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1544"
+      ]
+     },
+     "execution_count": 262,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -3041,7 +4095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 263,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3050,16 +4104,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 264,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "associations.tsv\n",
+      "my_data.xwz\n",
+      "my_data_derived.txt\n",
+      "persons-with-id.csv\n",
+      "persons.csv\n",
+      "tfidfvectorizer_model_schemaorg_linking\n"
+     ]
+    }
+   ],
    "source": [
     "! ls -p ../../data | egrep -v /$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 265,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3068,7 +4135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 266,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3077,16 +4144,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 267,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(association)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 268,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3101,7 +4177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 269,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3111,7 +4187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 270,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3122,16 +4198,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 271,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 3632\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Oct 20 10:54 associations.tsv\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 23 15:10 associations.tsv.20231123151033\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 23 15:10 associations.tsv.20231123151035\n",
+      "-rw-r--r--  1 mouffok  10067     477 Nov 23 15:41 associations.tsv.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:20 associations.tsv.20231127142049\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:20 associations.tsv.20231127142050\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:24 associations.tsv.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Dec  5 15:37 associations.tsv.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Dec  5 15:44 associations.tsv.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067     477 Feb  1 18:40 associations.tsv.20240201184048\n",
+      "-rw-r--r--  1 mouffok  10067     477 Feb  2 10:47 associations.tsv.20240202104741\n",
+      "-rw-r--r--  1 mouffok  10067     477 Feb  2 10:59 associations.tsv.20240202105941\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Oct 20 10:54 my_data.xwz\n",
+      "-rw-r--r--  1 mouffok  10067      16 Nov 23 15:41 my_data.xwz.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Nov 27 14:24 my_data.xwz.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Dec  5 15:37 my_data.xwz.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Dec  5 15:44 my_data.xwz.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067      16 Feb  1 18:40 my_data.xwz.20240201184048\n",
+      "-rw-r--r--  1 mouffok  10067      16 Feb  2 10:47 my_data.xwz.20240202104741\n",
+      "-rw-r--r--  1 mouffok  10067      16 Feb  2 10:59 my_data.xwz.20240202105941\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Oct 20 10:54 my_data_derived.txt\n",
+      "-rw-r--r--  1 mouffok  10067      24 Nov 23 15:41 my_data_derived.txt.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Nov 27 14:24 my_data_derived.txt.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Dec  5 15:37 my_data_derived.txt.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Dec  5 15:44 my_data_derived.txt.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067      24 Feb  1 18:40 my_data_derived.txt.20240201184048\n",
+      "-rw-r--r--  1 mouffok  10067      24 Feb  2 10:47 my_data_derived.txt.20240202104741\n",
+      "-rw-r--r--  1 mouffok  10067      24 Feb  2 10:59 my_data_derived.txt.20240202105941\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Oct 20 10:54 persons-with-id.csv\n",
+      "-rw-r--r--  1 mouffok  10067     126 Nov 23 15:41 persons-with-id.csv.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Nov 27 14:24 persons-with-id.csv.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Dec  5 15:37 persons-with-id.csv.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Dec  5 15:44 persons-with-id.csv.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067     126 Feb  1 18:40 persons-with-id.csv.20240201184048\n",
+      "-rw-r--r--  1 mouffok  10067     126 Feb  2 10:47 persons-with-id.csv.20240202104741\n",
+      "-rw-r--r--  1 mouffok  10067     126 Feb  2 10:59 persons-with-id.csv.20240202105941\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Oct 20 10:54 persons.csv\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Nov 23 15:10 persons.csv.20231123151035\n",
+      "-rw-r--r--  1 mouffok  10067      52 Nov 23 15:41 persons.csv.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Nov 27 14:20 persons.csv.20231127142050\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Nov 27 14:24 persons.csv.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Dec  5 15:37 persons.csv.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Dec  5 15:44 persons.csv.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067      52 Feb  1 18:40 persons.csv.20240201184048\n",
+      "-rw-r--r--  1 mouffok  10067      52 Feb  2 10:47 persons.csv.20240202104741\n",
+      "-rw-r--r--  1 mouffok  10067      52 Feb  2 10:59 persons.csv.20240202105941\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Oct 20 10:54 tfidfvectorizer_model_schemaorg_linking\n",
+      "-rw-r--r--  1 mouffok  10067  204848 Nov 23 15:41 tfidfvectorizer_model_schemaorg_linking.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Nov 27 14:24 tfidfvectorizer_model_schemaorg_linking.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Dec  5 15:37 tfidfvectorizer_model_schemaorg_linking.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Dec  5 15:44 tfidfvectorizer_model_schemaorg_linking.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067  204848 Feb  1 18:40 tfidfvectorizer_model_schemaorg_linking.20240201184048\n",
+      "-rw-r--r--  1 mouffok  10067  204848 Feb  2 10:47 tfidfvectorizer_model_schemaorg_linking.20240202104741\n",
+      "-rw-r--r--  1 mouffok  10067  204848 Feb  2 10:59 tfidfvectorizer_model_schemaorg_linking.20240202105941\n"
+     ]
+    }
+   ],
    "source": [
     "! ls -l ./downloaded/"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 272,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/getting-started/04 - Querying.ipynb
+++ b/examples/notebooks/getting-started/04 - Querying.ipynb
@@ -394,18 +394,18 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/645b04ee-09ba-4af2-8929-24f22e79975f',\n",
        " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
-       " '_createdAt': '2024-02-01T17:12:36.480Z',\n",
+       " '_createdAt': '2024-02-01T17:40:39.699Z',\n",
        " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
        " '_deprecated': False,\n",
-       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/incoming',\n",
-       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/outgoing',\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/outgoing',\n",
        " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
        " '_rev': 3,\n",
        " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
-       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
-       " '_updatedAt': '2024-02-01T17:12:36.836Z',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f',\n",
+       " '_updatedAt': '2024-02-01T17:40:39.925Z',\n",
        " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
       ]
      },
@@ -586,7 +586,7 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/645b04ee-09ba-4af2-8929-24f22e79975f',\n",
        " 'type': 'Person',\n",
        " 'award': 'Nobel',\n",
        " 'email': ['jane.doe@epfl.ch', 'jane.doe@example.org'],\n",
@@ -610,18 +610,18 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/645b04ee-09ba-4af2-8929-24f22e79975f',\n",
        " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
-       " '_createdAt': '2024-02-01T17:12:36.480Z',\n",
+       " '_createdAt': '2024-02-01T17:40:39.699Z',\n",
        " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
        " '_deprecated': False,\n",
-       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/incoming',\n",
-       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/outgoing',\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/outgoing',\n",
        " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
        " '_rev': 3,\n",
        " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
-       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
-       " '_updatedAt': '2024-02-01T17:12:36.836Z',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f',\n",
+       " '_updatedAt': '2024-02-01T17:40:39.925Z',\n",
        " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
       ]
      },
@@ -793,7 +793,7 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/c1919ecd-81ed-44e4-bbf8-5d2c5eeef11a',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/6a541028-8a0f-4a95-82f8-3472af91372e',\n",
        " 'type': 'Dataset',\n",
        " 'contribution': [{'type': 'Contribution',\n",
        "   'agent': {'type': 'Person', 'name': 'Jane Doe'}},\n",
@@ -804,7 +804,7 @@
        "    'type': 'DiskStorage',\n",
        "    '_rev': 1}},\n",
        "  'contentSize': {'unitCode': 'bytes', 'value': 477},\n",
-       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F746de37b-e8fd-41a3-b827-0e50369d44b6',\n",
+       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F3d70ede3-50d9-46bb-ad5e-d02abe186a2d',\n",
        "  'digest': {'algorithm': 'SHA-256',\n",
        "   'value': '789aa07948683fe036ac29811814a826b703b562f7d168eb70dee1fabde26859'},\n",
        "  'encodingFormat': 'text/tab-separated-values',\n",
@@ -951,18 +951,6 @@
        "      <th>award</th>\n",
        "      <th>name</th>\n",
        "      <th>email</th>\n",
-       "      <th>distribution.type</th>\n",
-       "      <th>distribution.atLocation.type</th>\n",
-       "      <th>distribution.atLocation.store.id</th>\n",
-       "      <th>distribution.atLocation.store.type</th>\n",
-       "      <th>distribution.atLocation.store._rev</th>\n",
-       "      <th>distribution.contentSize.unitCode</th>\n",
-       "      <th>distribution.contentSize.value</th>\n",
-       "      <th>distribution.contentUrl</th>\n",
-       "      <th>distribution.digest.algorithm</th>\n",
-       "      <th>distribution.digest.value</th>\n",
-       "      <th>distribution.encodingFormat</th>\n",
-       "      <th>distribution.name</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -973,18 +961,6 @@
        "      <td>[Nobel]</td>\n",
        "      <td>Jane Doe</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -993,38 +969,14 @@
        "      <td>[Nobel]</td>\n",
        "      <td>Jane Doe</td>\n",
        "      <td>[jane.doe@epfl.ch, jane.doe@example.org]</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Person</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>[Nobel]</td>\n",
        "      <td>Jane Doe</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>477.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
-       "      <td>text/tab-separated-values</td>\n",
-       "      <td>associations.tsv</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1034,52 +986,12 @@
        "                                                  id    type    award  \\\n",
        "0  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
        "1  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person      NaN   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
        "\n",
-       "       name                                     email distribution.type  \\\n",
-       "0  Jane Doe                                       NaN               NaN   \n",
-       "1  Jane Doe  [jane.doe@epfl.ch, jane.doe@example.org]               NaN   \n",
-       "2  Jane Doe                                       NaN      DataDownload   \n",
-       "\n",
-       "  distribution.atLocation.type  \\\n",
-       "0                          NaN   \n",
-       "1                          NaN   \n",
-       "2                     Location   \n",
-       "\n",
-       "                    distribution.atLocation.store.id  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
-       "\n",
-       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
-       "0                                NaN                                 NaN   \n",
-       "1                                NaN                                 NaN   \n",
-       "2                        DiskStorage                                 1.0   \n",
-       "\n",
-       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
-       "0                               NaN                             NaN   \n",
-       "1                               NaN                             NaN   \n",
-       "2                             bytes                           477.0   \n",
-       "\n",
-       "                             distribution.contentUrl  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
-       "\n",
-       "  distribution.digest.algorithm  \\\n",
-       "0                           NaN   \n",
-       "1                           NaN   \n",
-       "2                       SHA-256   \n",
-       "\n",
-       "                           distribution.digest.value  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
-       "\n",
-       "  distribution.encodingFormat distribution.name  \n",
-       "0                         NaN               NaN  \n",
-       "1                         NaN               NaN  \n",
-       "2   text/tab-separated-values  associations.tsv  "
+       "       name                                     email  \n",
+       "0  Jane Doe                                       NaN  \n",
+       "1  Jane Doe  [jane.doe@epfl.ch, jane.doe@example.org]  \n",
+       "2  Jane Doe                                       NaN  "
       ]
      },
      "execution_count": 48,
@@ -1127,17 +1039,13 @@
        "      <th>_deprecated</th>\n",
        "      <th>_incoming</th>\n",
        "      <th>_outgoing</th>\n",
-       "      <th>...</th>\n",
-       "      <th>distribution.atLocation.store.id</th>\n",
-       "      <th>distribution.atLocation.store.type</th>\n",
-       "      <th>distribution.atLocation.store._rev</th>\n",
-       "      <th>distribution.contentSize.unitCode</th>\n",
-       "      <th>distribution.contentSize.value</th>\n",
-       "      <th>distribution.contentUrl</th>\n",
-       "      <th>distribution.digest.algorithm</th>\n",
-       "      <th>distribution.digest.value</th>\n",
-       "      <th>distribution.encodingFormat</th>\n",
-       "      <th>distribution.name</th>\n",
+       "      <th>_project</th>\n",
+       "      <th>_rev</th>\n",
+       "      <th>_schemaProject</th>\n",
+       "      <th>_self</th>\n",
+       "      <th>_updatedAt</th>\n",
+       "      <th>_updatedBy</th>\n",
+       "      <th>email</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1153,16 +1061,12 @@
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:12:35.988Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1177,52 +1081,43 @@
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>3</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:12:36.836Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>[jane.doe@epfl.ch, jane.doe@example.org]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Person</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>[Nobel]</td>\n",
        "      <td>Jane Doe</td>\n",
        "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
-       "      <td>2022-12-07T16:10:19.607Z</td>\n",
+       "      <td>2024-02-01T17:40:39.386Z</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>477.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
-       "      <td>text/tab-separated-values</td>\n",
-       "      <td>associations.tsv</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:40:39.386Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>3 rows × 29 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "                                                  id    type    award  \\\n",
        "0  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
        "1  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person      NaN   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
        "\n",
        "       name                                     _constrainedBy  \\\n",
        "0  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
@@ -1232,7 +1127,7 @@
        "                 _createdAt  \\\n",
        "0  2024-02-01T17:12:35.988Z   \n",
        "1  2024-02-01T17:12:36.480Z   \n",
-       "2  2022-12-07T16:10:19.607Z   \n",
+       "2  2024-02-01T17:40:39.386Z   \n",
        "\n",
        "                                          _createdBy  _deprecated  \\\n",
        "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
@@ -1244,47 +1139,40 @@
        "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                                           _outgoing  ...  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "                                           _outgoing  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                    distribution.atLocation.store.id  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "                                            _project  _rev  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...     1   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/projects/...     3   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/projects/...     1   \n",
        "\n",
-       "   distribution.atLocation.store.type distribution.atLocation.store._rev  \\\n",
-       "0                                 NaN                                NaN   \n",
-       "1                                 NaN                                NaN   \n",
-       "2                         DiskStorage                                1.0   \n",
+       "                                      _schemaProject  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
        "\n",
-       "  distribution.contentSize.unitCode distribution.contentSize.value  \\\n",
-       "0                               NaN                            NaN   \n",
-       "1                               NaN                            NaN   \n",
-       "2                             bytes                          477.0   \n",
+       "                                               _self  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                             distribution.contentUrl  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "                 _updatedAt  \\\n",
+       "0  2024-02-01T17:12:35.988Z   \n",
+       "1  2024-02-01T17:12:36.836Z   \n",
+       "2  2024-02-01T17:40:39.386Z   \n",
        "\n",
-       "  distribution.digest.algorithm  \\\n",
-       "0                           NaN   \n",
-       "1                           NaN   \n",
-       "2                       SHA-256   \n",
+       "                                          _updatedBy  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...   \n",
        "\n",
-       "                           distribution.digest.value  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
-       "\n",
-       "  distribution.encodingFormat distribution.name  \n",
-       "0                         NaN               NaN  \n",
-       "1                         NaN               NaN  \n",
-       "2   text/tab-separated-values  associations.tsv  \n",
-       "\n",
-       "[3 rows x 29 columns]"
+       "                                      email  \n",
+       "0                                       NaN  \n",
+       "1  [jane.doe@epfl.ch, jane.doe@example.org]  \n",
+       "2                                       NaN  "
       ]
      },
      "execution_count": 49,
@@ -1582,7 +1470,7 @@
     {
      "data": {
       "text/plain": [
-       "1"
+       "0"
       ]
      },
      "execution_count": 56,
@@ -1620,100 +1508,17 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>type</th>\n",
-       "      <th>contribution</th>\n",
-       "      <th>distribution.type</th>\n",
-       "      <th>distribution.atLocation.type</th>\n",
-       "      <th>distribution.atLocation.store.id</th>\n",
-       "      <th>distribution.atLocation.store.type</th>\n",
-       "      <th>distribution.atLocation.store._rev</th>\n",
-       "      <th>distribution.contentSize.unitCode</th>\n",
-       "      <th>distribution.contentSize.value</th>\n",
-       "      <th>...</th>\n",
-       "      <th>_createdBy</th>\n",
-       "      <th>_deprecated</th>\n",
-       "      <th>_incoming</th>\n",
-       "      <th>_outgoing</th>\n",
-       "      <th>_project</th>\n",
-       "      <th>_rev</th>\n",
-       "      <th>_schemaProject</th>\n",
-       "      <th>_self</th>\n",
-       "      <th>_updatedAt</th>\n",
-       "      <th>_updatedBy</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Dataset</td>\n",
-       "      <td>[{'type': 'Contribution', 'agent': {'type': 'P...</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>477</td>\n",
-       "      <td>...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>2024-02-01T17:12:39.595Z</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1 rows × 27 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                                  id     type  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
-       "\n",
-       "                                        contribution distribution.type  \\\n",
-       "0  [{'type': 'Contribution', 'agent': {'type': 'P...      DataDownload   \n",
-       "\n",
-       "  distribution.atLocation.type  \\\n",
-       "0                     Location   \n",
-       "\n",
-       "                    distribution.atLocation.store.id  \\\n",
-       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
-       "\n",
-       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
-       "0                        DiskStorage                                   1   \n",
-       "\n",
-       "  distribution.contentSize.unitCode  distribution.contentSize.value  ...  \\\n",
-       "0                             bytes                             477  ...   \n",
-       "\n",
-       "                                          _createdBy _deprecated  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
-       "\n",
-       "                                           _incoming  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
-       "\n",
-       "                                           _outgoing  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
-       "\n",
-       "                                            _project _rev  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/projects/...    1   \n",
-       "\n",
-       "                                      _schemaProject  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
-       "\n",
-       "                                               _self  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
-       "\n",
-       "                 _updatedAt                                         _updatedBy  \n",
-       "0  2024-02-01T17:12:39.595Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
-       "\n",
-       "[1 rows x 27 columns]"
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
       ]
      },
      "execution_count": 57,
@@ -2136,17 +1941,13 @@
        "      <th>_deprecated</th>\n",
        "      <th>_incoming</th>\n",
        "      <th>_outgoing</th>\n",
-       "      <th>...</th>\n",
-       "      <th>distribution.atLocation.store.id</th>\n",
-       "      <th>distribution.atLocation.store.type</th>\n",
-       "      <th>distribution.atLocation.store._rev</th>\n",
-       "      <th>distribution.contentSize.unitCode</th>\n",
-       "      <th>distribution.contentSize.value</th>\n",
-       "      <th>distribution.contentUrl</th>\n",
-       "      <th>distribution.digest.algorithm</th>\n",
-       "      <th>distribution.digest.value</th>\n",
-       "      <th>distribution.encodingFormat</th>\n",
-       "      <th>distribution.name</th>\n",
+       "      <th>_project</th>\n",
+       "      <th>_rev</th>\n",
+       "      <th>_schemaProject</th>\n",
+       "      <th>_self</th>\n",
+       "      <th>_updatedAt</th>\n",
+       "      <th>_updatedBy</th>\n",
+       "      <th>email</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2162,16 +1963,12 @@
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:12:35.988Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -2186,52 +1983,43 @@
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>3</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:12:36.836Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>[jane.doe@epfl.ch, jane.doe@example.org]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>Person</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>[Nobel]</td>\n",
        "      <td>Jane Doe</td>\n",
        "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
-       "      <td>2022-12-07T16:10:19.607Z</td>\n",
+       "      <td>2024-02-01T17:40:39.386Z</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
        "      <td>False</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
        "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>477.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
-       "      <td>text/tab-separated-values</td>\n",
-       "      <td>associations.tsv</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:40:39.386Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>3 rows × 29 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
        "                                                  id    type    award  \\\n",
        "0  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
        "1  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person      NaN   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
        "\n",
        "       name                                     _constrainedBy  \\\n",
        "0  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
@@ -2241,7 +2029,7 @@
        "                 _createdAt  \\\n",
        "0  2024-02-01T17:12:35.988Z   \n",
        "1  2024-02-01T17:12:36.480Z   \n",
-       "2  2022-12-07T16:10:19.607Z   \n",
+       "2  2024-02-01T17:40:39.386Z   \n",
        "\n",
        "                                          _createdBy  _deprecated  \\\n",
        "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
@@ -2253,47 +2041,40 @@
        "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                                           _outgoing  ...  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "                                           _outgoing  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                    distribution.atLocation.store.id  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "                                            _project  _rev  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...     1   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/projects/...     3   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/projects/...     1   \n",
        "\n",
-       "   distribution.atLocation.store.type distribution.atLocation.store._rev  \\\n",
-       "0                                 NaN                                NaN   \n",
-       "1                                 NaN                                NaN   \n",
-       "2                         DiskStorage                                1.0   \n",
+       "                                      _schemaProject  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
        "\n",
-       "  distribution.contentSize.unitCode distribution.contentSize.value  \\\n",
-       "0                               NaN                            NaN   \n",
-       "1                               NaN                            NaN   \n",
-       "2                             bytes                          477.0   \n",
+       "                                               _self  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
        "\n",
-       "                             distribution.contentUrl  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "                 _updatedAt  \\\n",
+       "0  2024-02-01T17:12:35.988Z   \n",
+       "1  2024-02-01T17:12:36.836Z   \n",
+       "2  2024-02-01T17:40:39.386Z   \n",
        "\n",
-       "  distribution.digest.algorithm  \\\n",
-       "0                           NaN   \n",
-       "1                           NaN   \n",
-       "2                       SHA-256   \n",
+       "                                          _updatedBy  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...   \n",
        "\n",
-       "                           distribution.digest.value  \\\n",
-       "0                                                NaN   \n",
-       "1                                                NaN   \n",
-       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
-       "\n",
-       "  distribution.encodingFormat distribution.name  \n",
-       "0                         NaN               NaN  \n",
-       "1                         NaN               NaN  \n",
-       "2   text/tab-separated-values  associations.tsv  \n",
-       "\n",
-       "[3 rows x 29 columns]"
+       "                                      email  \n",
+       "0                                       NaN  \n",
+       "1  [jane.doe@epfl.ch, jane.doe@example.org]  \n",
+       "2                                       NaN  "
       ]
      },
      "execution_count": 66,
@@ -2538,16 +2319,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/edd6d380-a3e5-418d-a3f2-ee16bb76c23f'"
+       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/3d8ef57a-d12c-4fb8-b789-8e56af7625ef'"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2566,65 +2347,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 139,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'http://schema.org/Person'}}, {'term': {'_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, '_source': {'includes': ['@id', '@type']}, 'size': 3}\n"
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'Person'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n",
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'Dataset'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(0, 0)"
+      ]
+     },
+     "execution_count": 139,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "result_1 = forge.search(\n",
-    "    {\"@type\": \"http://schema.org/Person\"}, limit=3, search_endpoint='elastic', includes=[\"@id\", \"@type\"], view=view_id, debug=True\n",
+    "    {\"@type\": \"Person\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True\n",
     ")\n",
     "\n",
     "result_2 =  forge.search(\n",
-    "    {\"@type\": \"http://schema.org/Dataset\"}, limit=3, search_endpoint='elastic', includes=[\"@id\", \"@type\"], view=view_id\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 85,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(result_1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 79,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 79,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(result_2)"
+    "    {\"@type\": \"Dataset\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True\n",
+    ")\n",
+    "\n",
+    "len(result_1), len(result_2)"
    ]
   },
   {
@@ -2645,7 +2399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2654,34 +2408,235 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>agent.type</th>\n",
+       "      <th>agent.gender.id</th>\n",
+       "      <th>agent.gender.type</th>\n",
+       "      <th>agent.gender.label</th>\n",
+       "      <th>agent.name</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000383</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>female</td>\n",
+       "      <td>Marie Curie</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>46.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>marie_curie.txt</td>\n",
+       "      <td>Curie Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000384</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>male</td>\n",
+       "      <td>Albert Einstein</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>albert_einstein.txt</td>\n",
+       "      <td>Einstein Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id         type agent.type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "\n",
+       "                               agent.gender.id      agent.gender.type  \\\n",
+       "0  http://purl.obolibrary.org/obo/PATO_0000383  LabeledOntologyEntity   \n",
+       "1  http://purl.obolibrary.org/obo/PATO_0000384  LabeledOntologyEntity   \n",
+       "2                                          NaN                    NaN   \n",
+       "\n",
+       "  agent.gender.label       agent.name distribution.type  \\\n",
+       "0             female      Marie Curie      DataDownload   \n",
+       "1               male  Albert Einstein      DataDownload   \n",
+       "2                NaN         Jane Doe               NaN   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "1                     Location   \n",
+       "2                          NaN   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                 1.0   \n",
+       "1                        DiskStorage                                 1.0   \n",
+       "2                                NaN                                 NaN   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                             bytes                            46.0   \n",
+       "1                             bytes                            50.0   \n",
+       "2                               NaN                             NaN   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                       SHA-256   \n",
+       "1                       SHA-256   \n",
+       "2                           NaN   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0  e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...   \n",
+       "1  91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.encodingFormat    distribution.name                  name  \n",
+       "0                  text/plain      marie_curie.txt     Curie Association  \n",
+       "1                  text/plain  albert_einstein.txt  Einstein Association  \n",
+       "2                         NaN                  NaN                   NaN  "
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2691,27 +2646,88 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2727,7 +2743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2736,27 +2752,228 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>agent.type</th>\n",
+       "      <th>agent.gender.id</th>\n",
+       "      <th>agent.gender.type</th>\n",
+       "      <th>agent.gender.label</th>\n",
+       "      <th>agent.name</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000383</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>female</td>\n",
+       "      <td>Marie Curie</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>46.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>marie_curie.txt</td>\n",
+       "      <td>Curie Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>http://purl.obolibrary.org/obo/PATO_0000384</td>\n",
+       "      <td>LabeledOntologyEntity</td>\n",
+       "      <td>male</td>\n",
+       "      <td>Albert Einstein</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...</td>\n",
+       "      <td>text/plain</td>\n",
+       "      <td>albert_einstein.txt</td>\n",
+       "      <td>Einstein Association</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Association</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id         type agent.type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
+       "\n",
+       "                               agent.gender.id      agent.gender.type  \\\n",
+       "0  http://purl.obolibrary.org/obo/PATO_0000383  LabeledOntologyEntity   \n",
+       "1  http://purl.obolibrary.org/obo/PATO_0000384  LabeledOntologyEntity   \n",
+       "2                                          NaN                    NaN   \n",
+       "\n",
+       "  agent.gender.label       agent.name distribution.type  \\\n",
+       "0             female      Marie Curie      DataDownload   \n",
+       "1               male  Albert Einstein      DataDownload   \n",
+       "2                NaN         Jane Doe               NaN   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "1                     Location   \n",
+       "2                          NaN   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                 1.0   \n",
+       "1                        DiskStorage                                 1.0   \n",
+       "2                                NaN                                 NaN   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                             bytes                            46.0   \n",
+       "1                             bytes                            50.0   \n",
+       "2                               NaN                             NaN   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                       SHA-256   \n",
+       "1                       SHA-256   \n",
+       "2                           NaN   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0  e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...   \n",
+       "1  91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...   \n",
+       "2                                                NaN   \n",
+       "\n",
+       "  distribution.encodingFormat    distribution.name                  name  \n",
+       "0                  text/plain      marie_curie.txt     Curie Association  \n",
+       "1                  text/plain  albert_einstein.txt  Einstein Association  \n",
+       "2                         NaN                  NaN                   NaN  "
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2793,7 +3010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2803,7 +3020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2813,7 +3030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2822,20 +3039,166 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(association)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    id: \"\"\n",
+      "    type:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "    }\n",
+      "    annotation:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: Annotation\n",
+      "        hasBody:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            type:\n",
+      "            {\n",
+      "                id: \"\"\n",
+      "            }\n",
+      "            label: \"\"\n",
+      "            note: \"\"\n",
+      "        }\n",
+      "        hasTarget:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            type: AnnotationTarget\n",
+      "        }\n",
+      "        note: \"\"\n",
+      "    }\n",
+      "    brainLocation:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: BrainLocation\n",
+      "        atlasSpatialReferenceSystem:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            type: AtlasSpatialReferenceSystem\n",
+      "        }\n",
+      "        brainRegion:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            label: \"\"\n",
+      "        }\n",
+      "        coordinatesInBrainAtlas:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            valueX: 0.0\n",
+      "            valueY: 0.0\n",
+      "            valueZ: 0.0\n",
+      "        }\n",
+      "        coordinatesInSlice:\n",
+      "        {\n",
+      "            spatialReferenceSystem:\n",
+      "            {\n",
+      "                id: \"\"\n",
+      "                type: SpatialReferenceSystem\n",
+      "            }\n",
+      "            valueX: 0.0\n",
+      "            valueY: 0.0\n",
+      "            valueZ: 0.0\n",
+      "        }\n",
+      "        distanceToBoundary:\n",
+      "        {\n",
+      "            boundary:\n",
+      "            {\n",
+      "                id: \"\"\n",
+      "                label: \"\"\n",
+      "            }\n",
+      "            distance:\n",
+      "            {\n",
+      "                unitCode: \"\"\n",
+      "                value:\n",
+      "                [\n",
+      "                    0.0\n",
+      "                    0\n",
+      "                ]\n",
+      "            }\n",
+      "        }\n",
+      "        layer:\n",
+      "        {\n",
+      "            id: \"\"\n",
+      "            label: \"\"\n",
+      "        }\n",
+      "        longitudinalAxis:\n",
+      "        [\n",
+      "            Dorsal\n",
+      "            Ventral\n",
+      "        ]\n",
+      "        positionInLayer:\n",
+      "        [\n",
+      "            Deep\n",
+      "            Superficial\n",
+      "        ]\n",
+      "    }\n",
+      "    contribution:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "    }\n",
+      "    distribution:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: DataDownload\n",
+      "        contentSize:\n",
+      "        {\n",
+      "            unitCode: \"\"\n",
+      "            value:\n",
+      "            [\n",
+      "                0.0\n",
+      "                0\n",
+      "            ]\n",
+      "        }\n",
+      "        digest:\n",
+      "        {\n",
+      "            algorithm: \"\"\n",
+      "            value: \"\"\n",
+      "        }\n",
+      "        encodingFormat: \"\"\n",
+      "        license: \"\"\n",
+      "        name: \"\"\n",
+      "    }\n",
+      "    objectOfStudy:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: ObjectOfStudy\n",
+      "    }\n",
+      "    releaseDate: 9999-12-31T00:00:00\n",
+      "    subject:\n",
+      "    {\n",
+      "        id: \"\"\n",
+      "        type: Subject\n",
+      "    }\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "forge.template(\"Dataset\") # Templates help know which property to use when writing a query to serach for a given type"
    ]
@@ -2852,7 +3215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2868,7 +3231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2877,36 +3240,131 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    id: https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/7d0ba247-cff4-4292-b2d8-1fd1f8bd5159\n",
+      "    contributor: t1771\n",
+      "    name: John Smith\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "print(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>contributor</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>t1771</td>\n",
+       "      <td>John Smith</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>t1772</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>t1836</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id contributor        name\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...       t1771  John Smith\n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...       t1772    Jane Doe\n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...       t1836    Jane Doe"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2921,9 +3379,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "   PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "   PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "   PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "   PREFIX nsg: <https://neuroshapes.org/>\n",
+      "   PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "   PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "   PREFIX schema: <http://schema.org/>\n",
+      "   PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "   PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "   PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "   PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "   PREFIX : <https://neuroshapes.org/>\n",
+      "   \n",
+      "       SELECT ?id ?name ?contributor\n",
+      "       WHERE {\n",
+      "           ?id a schema:Dataset ;\n",
+      "           nsg:contribution/prov:agent ?contributor.\n",
+      "           ?contributor schema:name ?name.\n",
+      "       }\n",
+      "     LIMIT 3\n"
+     ]
+    }
+   ],
    "source": [
     "resources = forge.sparql(query, limit=3, debug=True)"
    ]
@@ -2940,7 +3431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2976,9 +3467,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 104,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   \n",
+      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "      PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "      PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "      PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "      PREFIX nsg: <https://neuroshapes.org/>\n",
+      "      PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "      PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "      PREFIX schema: <http://schema.org/>\n",
+      "      PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "      PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "      PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "      PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "      PREFIX : <https://neuroshapes.org/>\n",
+      "      SELECT ?id ?name\n",
+      "      WHERE {\n",
+      "          ?id a schema:Dataset ;\n",
+      "          nsg:contribution/prov:agent ?contributor.\n",
+      "          ?contributor schema:name ?name.\n",
+      "      }\n",
+      "      ORDER BY ?id\n",
+      "      LIMIT 3\n",
+      "      OFFSET 1\n"
+     ]
+    }
+   ],
    "source": [
     "# it is recommended to set 'rewrite' to 'False' to prevent the sparql query rewriting when a syntactically correct SPARQL query is provided.\n",
     "resources = forge.sparql(query, rewrite=False, limit=3, offset=1, debug=True) "
@@ -2986,36 +3512,126 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 105,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 106,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "kgforge.core.resource.Resource"
+      ]
+     },
+     "execution_count": 107,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>John Smith</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id        name\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...    Jane Doe\n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  John Smith\n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...    Jane Doe"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -3038,7 +3654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3072,9 +3688,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   \n",
+      "      PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "      PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "      PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "      PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "      PREFIX nsg: <https://neuroshapes.org/>\n",
+      "      PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "      PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "      PREFIX schema: <http://schema.org/>\n",
+      "      PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "      PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "      PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "      PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "      PREFIX : <https://neuroshapes.org/>\n",
+      "      SELECT ?id ?name\n",
+      "      WHERE {\n",
+      "          ?id a schema:Dataset ;\n",
+      "          nsg:contribution/prov:agent ?contributor.\n",
+      "          ?contributor schema:name ?name.\n",
+      "      }\n",
+      "      ORDER BY ?id\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "resources = forge.sparql(query_without_limit, rewrite=False, limit=None, offset=None, debug=True)"
@@ -3082,9 +3731,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "58"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
@@ -3099,7 +3759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3115,18 +3775,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query:\n",
+      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
+      "   PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
+      "   PREFIX dcterms: <http://purl.org/dc/terms/>\n",
+      "   PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
+      "   PREFIX nsg: <https://neuroshapes.org/>\n",
+      "   PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
+      "   PREFIX prov: <http://www.w3.org/ns/prov#>\n",
+      "   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
+      "   PREFIX schema: <http://schema.org/>\n",
+      "   PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
+      "   PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
+      "   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
+      "   PREFIX vann: <http://purl.org/vocab/vann/>\n",
+      "   PREFIX void: <http://rdfs.org/ns/void#>\n",
+      "   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "   PREFIX : <https://neuroshapes.org/>\n",
+      "   \n",
+      "       SELECT ?id ?name ?contributor\n",
+      "       WHERE {\n",
+      "           ?id a schema:Dataset ;\n",
+      "           nsg:contribution/prov:agent ?contributor.\n",
+      "           ?contributor schema:name ?name.\n",
+      "       }\n"
+     ]
+    }
+   ],
    "source": [
     "resources = forge.sparql(query_without_context, limit=None, debug=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "58"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
@@ -3151,7 +3854,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3161,7 +3864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3171,7 +3874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3180,9 +3883,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(association)"
    ]
@@ -3197,7 +3909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3220,7 +3932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3230,36 +3942,126 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "kgforge.core.resource.Resource"
+      ]
+     },
+     "execution_count": 123,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
+       "      <td>AA1543</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
+       "      <td>AA1542</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
+       "      <td>AA1544</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id    name\n",
+       "0  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1543\n",
+       "1  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1542\n",
+       "2  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1544"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -3282,7 +4084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3291,16 +4093,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "associations.tsv\n",
+      "my_data.xwz\n",
+      "my_data_derived.txt\n",
+      "persons-with-id.csv\n",
+      "persons.csv\n",
+      "tfidfvectorizer_model_schemaorg_linking\n"
+     ]
+    }
+   ],
    "source": [
     "! ls -p ../../data | egrep -v /$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3309,7 +4124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3318,16 +4133,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(association)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3342,7 +4166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3352,7 +4176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3363,16 +4187,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 2736\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Oct 20 10:54 associations.tsv\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 23 15:10 associations.tsv.20231123151033\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 23 15:10 associations.tsv.20231123151035\n",
+      "-rw-r--r--  1 mouffok  10067     477 Nov 23 15:41 associations.tsv.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:20 associations.tsv.20231127142049\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:20 associations.tsv.20231127142050\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:24 associations.tsv.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Dec  5 15:37 associations.tsv.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067     477 Dec  5 15:44 associations.tsv.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067     477 Feb  1 18:40 associations.tsv.20240201184048\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Oct 20 10:54 my_data.xwz\n",
+      "-rw-r--r--  1 mouffok  10067      16 Nov 23 15:41 my_data.xwz.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Nov 27 14:24 my_data.xwz.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Dec  5 15:37 my_data.xwz.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067      16 Dec  5 15:44 my_data.xwz.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067      16 Feb  1 18:40 my_data.xwz.20240201184048\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Oct 20 10:54 my_data_derived.txt\n",
+      "-rw-r--r--  1 mouffok  10067      24 Nov 23 15:41 my_data_derived.txt.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Nov 27 14:24 my_data_derived.txt.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Dec  5 15:37 my_data_derived.txt.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067      24 Dec  5 15:44 my_data_derived.txt.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067      24 Feb  1 18:40 my_data_derived.txt.20240201184048\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Oct 20 10:54 persons-with-id.csv\n",
+      "-rw-r--r--  1 mouffok  10067     126 Nov 23 15:41 persons-with-id.csv.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Nov 27 14:24 persons-with-id.csv.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Dec  5 15:37 persons-with-id.csv.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067     126 Dec  5 15:44 persons-with-id.csv.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067     126 Feb  1 18:40 persons-with-id.csv.20240201184048\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Oct 20 10:54 persons.csv\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Nov 23 15:10 persons.csv.20231123151035\n",
+      "-rw-r--r--  1 mouffok  10067      52 Nov 23 15:41 persons.csv.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Nov 27 14:20 persons.csv.20231127142050\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Nov 27 14:24 persons.csv.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Dec  5 15:37 persons.csv.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067      52 Dec  5 15:44 persons.csv.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067      52 Feb  1 18:40 persons.csv.20240201184048\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Oct 20 10:54 tfidfvectorizer_model_schemaorg_linking\n",
+      "-rw-r--r--  1 mouffok  10067  204848 Nov 23 15:41 tfidfvectorizer_model_schemaorg_linking.20231123154107\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Nov 27 14:24 tfidfvectorizer_model_schemaorg_linking.20231127142458\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Dec  5 15:37 tfidfvectorizer_model_schemaorg_linking.20231205153754\n",
+      "-rw-r--r--@ 1 mouffok  10067  204848 Dec  5 15:44 tfidfvectorizer_model_schemaorg_linking.20231205154444\n",
+      "-rw-r--r--  1 mouffok  10067  204848 Feb  1 18:40 tfidfvectorizer_model_schemaorg_linking.20240201184048\n"
+     ]
+    }
+   ],
    "source": [
     "! ls -l ./downloaded/"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/getting-started/04 - Querying.ipynb
+++ b/examples/notebooks/getting-started/04 - Querying.ipynb
@@ -41,27 +41,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "Exception",
-     "evalue": "Mapping loading failed",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m forge \u001b[38;5;241m=\u001b[39m \u001b[43mKnowledgeGraphForge\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m../../configurations/forge.yml\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/forge.py:249\u001b[0m, in \u001b[0;36mKnowledgeGraphForge.__init__\u001b[0;34m(self, configuration, **kwargs)\u001b[0m\n\u001b[1;32m    246\u001b[0m resolvers_config \u001b[38;5;241m=\u001b[39m config\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mResolvers\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[1;32m    247\u001b[0m \u001b[38;5;66;03m# Format: Optional[Dict[scope_name, Dict[resolver_name, Resolver]]].\u001b[39;00m\n\u001b[1;32m    248\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_resolvers: Optional[Dict[\u001b[38;5;28mstr\u001b[39m, Dict[\u001b[38;5;28mstr\u001b[39m, Resolver]]] \u001b[38;5;241m=\u001b[39m (\n\u001b[0;32m--> 249\u001b[0m     \u001b[43mprepare_resolvers\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresolvers_config\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstore_config\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    250\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m resolvers_config\n\u001b[1;32m    251\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    252\u001b[0m )\n\u001b[1;32m    254\u001b[0m \u001b[38;5;66;03m# Formatters.\u001b[39;00m\n\u001b[1;32m    255\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_formatters: Optional[Dict[\u001b[38;5;28mstr\u001b[39m, \u001b[38;5;28mstr\u001b[39m]] \u001b[38;5;241m=\u001b[39m config\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mFormatters\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/forge.py:958\u001b[0m, in \u001b[0;36mprepare_resolvers\u001b[0;34m(config, store_config)\u001b[0m\n\u001b[1;32m    955\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprepare_resolvers\u001b[39m(\n\u001b[1;32m    956\u001b[0m     config: Dict, store_config: Dict\n\u001b[1;32m    957\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Dict[\u001b[38;5;28mstr\u001b[39m, Resolver]]:\n\u001b[0;32m--> 958\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m {\n\u001b[1;32m    959\u001b[0m         scope: \u001b[38;5;28mdict\u001b[39m(prepare_resolver(x, store_config) \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m configs)\n\u001b[1;32m    960\u001b[0m         \u001b[38;5;28;01mfor\u001b[39;00m scope, configs \u001b[38;5;129;01min\u001b[39;00m config\u001b[38;5;241m.\u001b[39mitems()\n\u001b[1;32m    961\u001b[0m     }\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/forge.py:959\u001b[0m, in \u001b[0;36m<dictcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    955\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprepare_resolvers\u001b[39m(\n\u001b[1;32m    956\u001b[0m     config: Dict, store_config: Dict\n\u001b[1;32m    957\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Dict[\u001b[38;5;28mstr\u001b[39m, Resolver]]:\n\u001b[1;32m    958\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m {\n\u001b[0;32m--> 959\u001b[0m         scope: \u001b[38;5;28;43mdict\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mprepare_resolver\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstore_config\u001b[49m\u001b[43m)\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mx\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mconfigs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    960\u001b[0m         \u001b[38;5;28;01mfor\u001b[39;00m scope, configs \u001b[38;5;129;01min\u001b[39;00m config\u001b[38;5;241m.\u001b[39mitems()\n\u001b[1;32m    961\u001b[0m     }\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/forge.py:959\u001b[0m, in \u001b[0;36m<genexpr>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    955\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mprepare_resolvers\u001b[39m(\n\u001b[1;32m    956\u001b[0m     config: Dict, store_config: Dict\n\u001b[1;32m    957\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Dict[\u001b[38;5;28mstr\u001b[39m, Resolver]]:\n\u001b[1;32m    958\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m {\n\u001b[0;32m--> 959\u001b[0m         scope: \u001b[38;5;28mdict\u001b[39m(\u001b[43mprepare_resolver\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstore_config\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m configs)\n\u001b[1;32m    960\u001b[0m         \u001b[38;5;28;01mfor\u001b[39;00m scope, configs \u001b[38;5;129;01min\u001b[39;00m config\u001b[38;5;241m.\u001b[39mitems()\n\u001b[1;32m    961\u001b[0m     }\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/forge.py:982\u001b[0m, in \u001b[0;36mprepare_resolver\u001b[0;34m(config, store_config)\u001b[0m\n\u001b[1;32m    980\u001b[0m resolver_name \u001b[38;5;241m=\u001b[39m config\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mresolver\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    981\u001b[0m resolver \u001b[38;5;241m=\u001b[39m import_class(resolver_name, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mresolvers\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 982\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m resolver\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m, \u001b[43mresolver\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mconfig\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/specializations/resolvers/demo_resolver.py:33\u001b[0m, in \u001b[0;36mDemoResolver.__init__\u001b[0;34m(self, source, targets, result_resource_mapping, **source_config)\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, source: \u001b[38;5;28mstr\u001b[39m, targets: List[Dict[\u001b[38;5;28mstr\u001b[39m, Any]], result_resource_mapping: \u001b[38;5;28mstr\u001b[39m,\n\u001b[1;32m     32\u001b[0m              \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39msource_config) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m---> 33\u001b[0m     \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__init__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43msource\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtargets\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mresult_resource_mapping\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43msource_config\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/archetypes/resolver.py:53\u001b[0m, in \u001b[0;36mResolver.__init__\u001b[0;34m(self, source, targets, result_resource_mapping, **source_config)\u001b[0m\n\u001b[1;32m     51\u001b[0m         filters \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m     52\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtargets[target[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124midentifier\u001b[39m\u001b[38;5;124m\"\u001b[39m]] \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbucket\u001b[39m\u001b[38;5;124m\"\u001b[39m: target[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbucket\u001b[39m\u001b[38;5;124m\"\u001b[39m], \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfilters\u001b[39m\u001b[38;5;124m\"\u001b[39m: filters}\n\u001b[0;32m---> 53\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mresult_mapping: Any \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmapping\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload\u001b[49m\u001b[43m(\u001b[49m\u001b[43mresult_resource_mapping\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     54\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mservice: Any \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_initialize_service(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msource, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtargets, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39msource_config)\n",
-      "File \u001b[0;32m~/work_dir/nexus-forge/venv/lib/python3.8/site-packages/kgforge/core/archetypes/mapping.py:69\u001b[0m, in \u001b[0;36mMapping.load\u001b[0;34m(cls, source, mapping_type)\u001b[0m\n\u001b[1;32m     67\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m e \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     68\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m e\n\u001b[0;32m---> 69\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mMapping loading failed\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     71\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m mapping_type \u001b[38;5;241m==\u001b[39m MappingType\u001b[38;5;241m.\u001b[39mFILE:\n\u001b[1;32m     72\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mcls\u001b[39m\u001b[38;5;241m.\u001b[39mload_file(source)\n",
-      "\u001b[0;31mException\u001b[0m: Mapping loading failed"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge = KnowledgeGraphForge(\"../../configurations/forge.yml\")"
    ]
@@ -76,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,16 +92,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(jane)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,9 +119,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource == jane"
    ]
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,25 +156,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(jane)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _tag_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.tag(jane, \"v1\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,23 +201,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _update_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.update(jane)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.317601Z",
      "start_time": "2019-09-23T18:50:21.310418Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    # DemoStore\n",
@@ -211,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.332678Z",
@@ -225,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.370051Z",
@@ -239,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,41 +283,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-09-23T18:50:21.379911Z",
      "start_time": "2019-09-23T18:50:21.373539Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "jane_v1 == jane_v1_tag"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "jane_v1 == jane_v1_rev"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "jane_v1 != jane"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    # DemoStore\n",
@@ -303,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,27 +388,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
+       " '_createdAt': '2024-02-01T17:12:36.480Z',\n",
+       " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
+       " '_deprecated': False,\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/outgoing',\n",
+       " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
+       " '_rev': 3,\n",
+       " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       " '_updatedAt': '2024-02-01T17:12:36.836Z',\n",
+       " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource._store_metadata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Action(error=None, message=None, operation='retrieve', succeeded=True)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource._last_action"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource._synchronized"
    ]
@@ -348,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,16 +496,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> False\n",
+      "<error> RegistrationError: resource 'https://myincreadibleid-987654321' already exists in project 'github-users/ssssarah'\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(other_resource)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,9 +542,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "same_resource_id == same_resource_url"
    ]
@@ -429,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,36 +580,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       " 'type': 'Person',\n",
+       " 'award': 'Nobel',\n",
+       " 'email': ['jane.doe@epfl.ch', 'jane.doe@example.org'],\n",
+       " 'name': 'Jane Doe'}"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_json(resource)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
+       " '_createdAt': '2024-02-01T17:12:36.480Z',\n",
+       " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
+       " '_deprecated': False,\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394/outgoing',\n",
+       " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
+       " '_rev': 3,\n",
+       " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F2b4f6036-004b-4fe6-a7fc-a63482b58394',\n",
+       " '_updatedAt': '2024-02-01T17:12:36.836Z',\n",
+       " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource._store_metadata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Action(error=None, message=None, operation='retrieve', succeeded=True)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource._last_action"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource._synchronized"
    ]
@@ -482,18 +684,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404 Client Error: Not Found for url: https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/%3A%2F%2F123/source\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "resource = forge.retrieve(\"123\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resource is None"
    ]
@@ -516,7 +739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,18 +769,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> _register_one\n",
+      "<succeeded> True\n"
+     ]
+    }
+   ],
    "source": [
     "forge.register(dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/c1919ecd-81ed-44e4-bbf8-5d2c5eeef11a',\n",
+       " 'type': 'Dataset',\n",
+       " 'contribution': [{'type': 'Contribution',\n",
+       "   'agent': {'type': 'Person', 'name': 'Jane Doe'}},\n",
+       "  {'type': 'Contribution', 'agent': {'type': 'Person', 'name': 'John Smith'}}],\n",
+       " 'distribution': {'type': 'DataDownload',\n",
+       "  'atLocation': {'type': 'Location',\n",
+       "   'store': {'id': 'https://bluebrain.github.io/nexus/vocabulary/diskStorageDefault',\n",
+       "    'type': 'DiskStorage',\n",
+       "    '_rev': 1}},\n",
+       "  'contentSize': {'unitCode': 'bytes', 'value': 477},\n",
+       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F746de37b-e8fd-41a3-b827-0e50369d44b6',\n",
+       "  'digest': {'algorithm': 'SHA-256',\n",
+       "   'value': '789aa07948683fe036ac29811814a826b703b562f7d168eb70dee1fabde26859'},\n",
+       "  'encodingFormat': 'text/tab-separated-values',\n",
+       "  'name': 'associations.tsv'}}"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_json(dataset)"
    ]
@@ -582,7 +840,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,45 +882,436 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>award</th>\n",
+       "      <th>name</th>\n",
+       "      <th>email</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>[Nobel]</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>[Nobel]</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>[jane.doe@epfl.ch, jane.doe@example.org]</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
+       "      <td>text/tab-separated-values</td>\n",
+       "      <td>associations.tsv</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id    type    award  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person      NaN   \n",
+       "\n",
+       "       name                                     email distribution.type  \\\n",
+       "0  Jane Doe                                       NaN               NaN   \n",
+       "1  Jane Doe  [jane.doe@epfl.ch, jane.doe@example.org]               NaN   \n",
+       "2  Jane Doe                                       NaN      DataDownload   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                          NaN   \n",
+       "1                          NaN   \n",
+       "2                     Location   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                                NaN                                 NaN   \n",
+       "1                                NaN                                 NaN   \n",
+       "2                        DiskStorage                                 1.0   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                               NaN                             NaN   \n",
+       "1                               NaN                             NaN   \n",
+       "2                             bytes                           477.0   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                           NaN   \n",
+       "1                           NaN   \n",
+       "2                       SHA-256   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
+       "\n",
+       "  distribution.encodingFormat distribution.name  \n",
+       "0                         NaN               NaN  \n",
+       "1                         NaN               NaN  \n",
+       "2   text/tab-separated-values  associations.tsv  "
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>award</th>\n",
+       "      <th>name</th>\n",
+       "      <th>_constrainedBy</th>\n",
+       "      <th>_createdAt</th>\n",
+       "      <th>_createdBy</th>\n",
+       "      <th>_deprecated</th>\n",
+       "      <th>_incoming</th>\n",
+       "      <th>_outgoing</th>\n",
+       "      <th>...</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>[Nobel]</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
+       "      <td>2024-02-01T17:12:35.988Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>[Nobel]</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
+       "      <td>2024-02-01T17:12:36.480Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
+       "      <td>2022-12-07T16:10:19.607Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
+       "      <td>text/tab-separated-values</td>\n",
+       "      <td>associations.tsv</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3 rows × 29 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id    type    award  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person      NaN   \n",
+       "\n",
+       "       name                                     _constrainedBy  \\\n",
+       "0  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
+       "1  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
+       "2  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
+       "\n",
+       "                 _createdAt  \\\n",
+       "0  2024-02-01T17:12:35.988Z   \n",
+       "1  2024-02-01T17:12:36.480Z   \n",
+       "2  2022-12-07T16:10:19.607Z   \n",
+       "\n",
+       "                                          _createdBy  _deprecated  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
+       "\n",
+       "                                           _incoming  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                                           _outgoing  ...  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "\n",
+       "   distribution.atLocation.store.type distribution.atLocation.store._rev  \\\n",
+       "0                                 NaN                                NaN   \n",
+       "1                                 NaN                                NaN   \n",
+       "2                         DiskStorage                                1.0   \n",
+       "\n",
+       "  distribution.contentSize.unitCode distribution.contentSize.value  \\\n",
+       "0                               NaN                            NaN   \n",
+       "1                               NaN                            NaN   \n",
+       "2                             bytes                          477.0   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                           NaN   \n",
+       "1                           NaN   \n",
+       "2                       SHA-256   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
+       "\n",
+       "  distribution.encodingFormat distribution.name  \n",
+       "0                         NaN               NaN  \n",
+       "1                         NaN               NaN  \n",
+       "2   text/tab-separated-values  associations.tsv  \n",
+       "\n",
+       "[3 rows x 29 columns]"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources, store_metadata=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Search results are not synchronized\n",
     "resources[0]._synchronized"
@@ -686,7 +1335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,20 +1345,180 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "      <th>name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
+       "      <td>text/tab-separated-values</td>\n",
+       "      <td>associations.tsv</td>\n",
+       "      <td>Interesting Persons</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
+       "      <td>text/tab-separated-values</td>\n",
+       "      <td>associations.tsv</td>\n",
+       "      <td>Interesting Persons</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
+       "      <td>text/tab-separated-values</td>\n",
+       "      <td>associations.tsv</td>\n",
+       "      <td>Interesting Persons</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id     type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "\n",
+       "  distribution.type distribution.atLocation.type  \\\n",
+       "0      DataDownload                     Location   \n",
+       "1      DataDownload                     Location   \n",
+       "2      DataDownload                     Location   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                   1   \n",
+       "1                        DiskStorage                                   1   \n",
+       "2                        DiskStorage                                   1   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                             bytes                             477   \n",
+       "1                             bytes                             477   \n",
+       "2                             bytes                             477   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                       SHA-256   \n",
+       "1                       SHA-256   \n",
+       "2                       SHA-256   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
+       "1  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
+       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
+       "\n",
+       "  distribution.encodingFormat distribution.name                 name  \n",
+       "0   text/tab-separated-values  associations.tsv  Interesting Persons  \n",
+       "1   text/tab-separated-values  associations.tsv  Interesting Persons  \n",
+       "2   text/tab-separated-values  associations.tsv  Interesting Persons  "
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -731,7 +1540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,27 +1556,171 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>contribution</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>...</th>\n",
+       "      <th>_createdBy</th>\n",
+       "      <th>_deprecated</th>\n",
+       "      <th>_incoming</th>\n",
+       "      <th>_outgoing</th>\n",
+       "      <th>_project</th>\n",
+       "      <th>_rev</th>\n",
+       "      <th>_schemaProject</th>\n",
+       "      <th>_self</th>\n",
+       "      <th>_updatedAt</th>\n",
+       "      <th>_updatedBy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>[{'type': 'Contribution', 'agent': {'type': 'P...</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2024-02-01T17:12:39.595Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id     type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "\n",
+       "                                        contribution distribution.type  \\\n",
+       "0  [{'type': 'Contribution', 'agent': {'type': 'P...      DataDownload   \n",
+       "\n",
+       "  distribution.atLocation.type  \\\n",
+       "0                     Location   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                   1   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  ...  \\\n",
+       "0                             bytes                             477  ...   \n",
+       "\n",
+       "                                          _createdBy _deprecated  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
+       "\n",
+       "                                           _incoming  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                                           _outgoing  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                                            _project _rev  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...    1   \n",
+       "\n",
+       "                                      _schemaProject  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "\n",
+       "                                               _self  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                 _updatedAt                                         _updatedBy  \n",
+       "0  2024-02-01T17:12:39.595Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
+       "\n",
+       "[1 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources, store_metadata=True)"
    ]
@@ -790,16 +1743,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['__eq__ (EQUAL)',\n",
+       " '__ne__ (NOT_EQUAL)',\n",
+       " '__lt__ (LOWER_THAN)',\n",
+       " '__le__ (LOWER_OR_Equal_Than)',\n",
+       " '__gt__ (GREATER_Than)',\n",
+       " '__ge__ (GREATER_OR_Equal_Than)']"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[f\"{op.value} ({op.name})\" for op in FilterOperator] # These are equivalent to the Python comparison operators"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,27 +1783,245 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>distribution.type</th>\n",
+       "      <th>distribution.atLocation.type</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>...</th>\n",
+       "      <th>_createdBy</th>\n",
+       "      <th>_deprecated</th>\n",
+       "      <th>_incoming</th>\n",
+       "      <th>_outgoing</th>\n",
+       "      <th>_project</th>\n",
+       "      <th>_rev</th>\n",
+       "      <th>_schemaProject</th>\n",
+       "      <th>_self</th>\n",
+       "      <th>_updatedAt</th>\n",
+       "      <th>_updatedBy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2022-12-07T16:07:59.200Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2022-12-08T09:46:09.139Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Dataset</td>\n",
+       "      <td>DataDownload</td>\n",
+       "      <td>Location</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/projects/...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>2022-12-08T12:22:35.660Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3 rows × 27 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id     type  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Dataset   \n",
+       "\n",
+       "  distribution.type distribution.atLocation.type  \\\n",
+       "0      DataDownload                     Location   \n",
+       "1      DataDownload                     Location   \n",
+       "2      DataDownload                     Location   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "\n",
+       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
+       "0                        DiskStorage                                   1   \n",
+       "1                        DiskStorage                                   1   \n",
+       "2                        DiskStorage                                   1   \n",
+       "\n",
+       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
+       "0                             bytes                             477   \n",
+       "1                             bytes                             477   \n",
+       "2                             bytes                             477   \n",
+       "\n",
+       "                             distribution.contentUrl  ...  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/files/git...  ...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/files/git...  ...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/files/git...  ...   \n",
+       "\n",
+       "                                          _createdBy _deprecated  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...       False   \n",
+       "\n",
+       "                                           _incoming  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                                           _outgoing  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                                            _project _rev  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...    1   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/projects/...    1   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/projects/...    1   \n",
+       "\n",
+       "                                      _schemaProject  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/projects/...   \n",
+       "\n",
+       "                                               _self  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                 _updatedAt                                         _updatedBy  \n",
+       "0  2022-12-07T16:07:59.200Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
+       "1  2022-12-08T09:46:09.139Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
+       "2  2022-12-08T12:22:35.660Z  https://sandbox.bluebrainnexus.io/v1/realms/gi...  \n",
+       "\n",
+       "[3 rows x 27 columns]"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources, store_metadata=True)"
    ]
@@ -848,7 +2035,10 @@
     "\n",
     "Two types of search endpoints are supported: 'sparql' (default) for graph queries and 'elastic' for document oriented queries. The types of available search endpoint can be configured (see [00-Initialization.ipynb](00%20-%20Initialization.ipynb) for an example of search endpoints config) or set when creating a KnowledgeGraphForge session using the 'searchendpoints' arguments.\n",
     "\n",
-    "The search endpoint to hit when calling forge.search(...) is 'sparql' by default but can be specified using the 'search_endpoint' argument."
+    "The search endpoint to hit when calling forge.search(...) is 'sparql' by default but can be specified using the 'search_endpoint' argument.\n",
+    "\n",
+    "The data that is available through these searchendpoints is limited to data indexed in specific indices that are configured through views. The project is set-up with default a elastic search view that indexes all data, and a default sparql view that indexes all data.\n",
+    "You may define a view that targets a subset of the data based on some filters."
    ]
   },
   {
@@ -861,7 +2051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,27 +2062,245 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>award</th>\n",
+       "      <th>name</th>\n",
+       "      <th>_constrainedBy</th>\n",
+       "      <th>_createdAt</th>\n",
+       "      <th>_createdBy</th>\n",
+       "      <th>_deprecated</th>\n",
+       "      <th>_incoming</th>\n",
+       "      <th>_outgoing</th>\n",
+       "      <th>...</th>\n",
+       "      <th>distribution.atLocation.store.id</th>\n",
+       "      <th>distribution.atLocation.store.type</th>\n",
+       "      <th>distribution.atLocation.store._rev</th>\n",
+       "      <th>distribution.contentSize.unitCode</th>\n",
+       "      <th>distribution.contentSize.value</th>\n",
+       "      <th>distribution.contentUrl</th>\n",
+       "      <th>distribution.digest.algorithm</th>\n",
+       "      <th>distribution.digest.value</th>\n",
+       "      <th>distribution.encodingFormat</th>\n",
+       "      <th>distribution.name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>[Nobel]</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
+       "      <td>2024-02-01T17:12:35.988Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>[Nobel]</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
+       "      <td>2024-02-01T17:12:36.480Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>Person</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Jane Doe</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/schemas/unco...</td>\n",
+       "      <td>2022-12-07T16:10:19.607Z</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/realms/gi...</td>\n",
+       "      <td>False</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
+       "      <td>DiskStorage</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>bytes</td>\n",
+       "      <td>477.0</td>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
+       "      <td>SHA-256</td>\n",
+       "      <td>789aa07948683fe036ac29811814a826b703b562f7d168...</td>\n",
+       "      <td>text/tab-separated-values</td>\n",
+       "      <td>associations.tsv</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3 rows × 29 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id    type    award  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Person  [Nobel]   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Person      NaN   \n",
+       "\n",
+       "       name                                     _constrainedBy  \\\n",
+       "0  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
+       "1  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
+       "2  Jane Doe  https://bluebrain.github.io/nexus/schemas/unco...   \n",
+       "\n",
+       "                 _createdAt  \\\n",
+       "0  2024-02-01T17:12:35.988Z   \n",
+       "1  2024-02-01T17:12:36.480Z   \n",
+       "2  2022-12-07T16:10:19.607Z   \n",
+       "\n",
+       "                                          _createdBy  _deprecated  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/realms/gi...        False   \n",
+       "\n",
+       "                                           _incoming  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...   \n",
+       "\n",
+       "                                           _outgoing  ...  \\\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  ...   \n",
+       "\n",
+       "                    distribution.atLocation.store.id  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
+       "\n",
+       "   distribution.atLocation.store.type distribution.atLocation.store._rev  \\\n",
+       "0                                 NaN                                NaN   \n",
+       "1                                 NaN                                NaN   \n",
+       "2                         DiskStorage                                1.0   \n",
+       "\n",
+       "  distribution.contentSize.unitCode distribution.contentSize.value  \\\n",
+       "0                               NaN                            NaN   \n",
+       "1                               NaN                            NaN   \n",
+       "2                             bytes                          477.0   \n",
+       "\n",
+       "                             distribution.contentUrl  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
+       "\n",
+       "  distribution.digest.algorithm  \\\n",
+       "0                           NaN   \n",
+       "1                           NaN   \n",
+       "2                       SHA-256   \n",
+       "\n",
+       "                           distribution.digest.value  \\\n",
+       "0                                                NaN   \n",
+       "1                                                NaN   \n",
+       "2  789aa07948683fe036ac29811814a826b703b562f7d168...   \n",
+       "\n",
+       "  distribution.encodingFormat distribution.name  \n",
+       "0                         NaN               NaN  \n",
+       "1                         NaN               NaN  \n",
+       "2   text/tab-separated-values  associations.tsv  \n",
+       "\n",
+       "[3 rows x 29 columns]"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources, store_metadata=True)"
    ]
@@ -907,49 +2315,139 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Search for resources of type Person and retrieve their ids and names.\n",
     "filters = {\"@type\": \"http://schema.org/Person\"}\n",
-    "resources = forge.search(filters, limit=3, \n",
-    "                         search_endpoint='elastic', \n",
-    "                         includes=[\"@id\", \"@type\"]) # fields can also be excluded with 'excludes'"
+    "resources = forge.search(\n",
+    "    filters, limit=3, search_endpoint='elastic', includes=[\"@id\", \"@type\"]\n",
+    ") # fields can also be excluded with 'excludes'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>http://schema.org/Person</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>http://schema.org/Person</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
+       "      <td>http://schema.org/Person</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                  id                      type\n",
+       "0  https://sandbox.bluebrainnexus.io/v1/resources...  http://schema.org/Person\n",
+       "1  https://sandbox.bluebrainnexus.io/v1/resources...  http://schema.org/Person\n",
+       "2  https://sandbox.bluebrainnexus.io/v1/resources...  http://schema.org/Person"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "forge.as_dataframe(resources, store_metadata=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Search results are not synchronized\n",
     "resources[0]._synchronized"
@@ -957,20 +2455,183 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/e01663b6-604b-42db-b958-da9fbc1baca2'"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "resources[0].id"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'http://schema.org/Person'"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resources[0].type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### ElasticSearch Endpoint - Alternative view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Create a view that only indexes resources of type http://schema.org/Person"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
-    "resources[0].type"
+    "import requests \n",
+    "\n",
+    "# TODO fix view definition, doesn't seem to work with filters, see if mapping is the problem\n",
+    "payload = {\n",
+    "    \"@type\": [\"View\", \"ElasticSearchView\"],\n",
+    "    \"pipeline\": [{\n",
+    "                \"name\": \"filterByType\",\n",
+    "                \"config\": {\"types\": [\"http://schema.org/Person\"]}\n",
+    "            }],\n",
+    "    \"mapping\": {}\n",
+    "}\n",
+    "\n",
+    "url = f\"{forge._store.endpoint}/views/{forge._store.bucket}\"\n",
+    "\n",
+    "headers = {\n",
+    "    \"mode\": \"cors\",\n",
+    "    \"Content-Type\": \"application/json\",\n",
+    "    \"Accept\": \"application/ld+json, application/json\",\n",
+    "    \"Authorization\": \"Bearer \" + forge._store.token\n",
+    "}\n",
+    "response = requests.post(url=url, headers=headers, json=payload)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/edd6d380-a3e5-418d-a3f2-ee16bb76c23f'"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "view_id = response.json()[\"@id\"]\n",
+    "view_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Query the view (may take a few seconds to get a response due to indexing time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'http://schema.org/Person'}}, {'term': {'_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, '_source': {'includes': ['@id', '@type']}, 'size': 3}\n"
+     ]
+    }
+   ],
+   "source": [
+    "result_1 = forge.search(\n",
+    "    {\"@type\": \"http://schema.org/Person\"}, limit=3, search_endpoint='elastic', includes=[\"@id\", \"@type\"], view=view_id, debug=True\n",
+    ")\n",
+    "\n",
+    "result_2 =  forge.search(\n",
+    "    {\"@type\": \"http://schema.org/Dataset\"}, limit=3, search_endpoint='elastic', includes=[\"@id\", \"@type\"], view=view_id\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(result_1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(result_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Providing a view is feature that is also available through the forge.elastic, and forge.sparql calls"
    ]
   },
   {
@@ -1721,9 +3382,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "forge_venv",
    "language": "python",
-   "name": "python3"
+   "name": "venv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/notebooks/getting-started/04 - Querying.ipynb
+++ b/examples/notebooks/getting-started/04 - Querying.ipynb
@@ -394,18 +394,18 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/645b04ee-09ba-4af2-8929-24f22e79975f',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/5eb29fff-931d-454e-b836-10ca68578899',\n",
        " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
-       " '_createdAt': '2024-02-01T17:40:39.699Z',\n",
+       " '_createdAt': '2024-02-02T09:19:23.366Z',\n",
        " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
        " '_deprecated': False,\n",
-       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/incoming',\n",
-       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/outgoing',\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/outgoing',\n",
        " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
        " '_rev': 3,\n",
        " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
-       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f',\n",
-       " '_updatedAt': '2024-02-01T17:40:39.925Z',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899',\n",
+       " '_updatedAt': '2024-02-02T09:19:23.719Z',\n",
        " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
       ]
      },
@@ -586,7 +586,7 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/645b04ee-09ba-4af2-8929-24f22e79975f',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/5eb29fff-931d-454e-b836-10ca68578899',\n",
        " 'type': 'Person',\n",
        " 'award': 'Nobel',\n",
        " 'email': ['jane.doe@epfl.ch', 'jane.doe@example.org'],\n",
@@ -610,18 +610,18 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/645b04ee-09ba-4af2-8929-24f22e79975f',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/5eb29fff-931d-454e-b836-10ca68578899',\n",
        " '_constrainedBy': 'https://bluebrain.github.io/nexus/schemas/unconstrained.json',\n",
-       " '_createdAt': '2024-02-01T17:40:39.699Z',\n",
+       " '_createdAt': '2024-02-02T09:19:23.366Z',\n",
        " '_createdBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah',\n",
        " '_deprecated': False,\n",
-       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/incoming',\n",
-       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f/outgoing',\n",
+       " '_incoming': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/incoming',\n",
+       " '_outgoing': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899/outgoing',\n",
        " '_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
        " '_rev': 3,\n",
        " '_schemaProject': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah',\n",
-       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F645b04ee-09ba-4af2-8929-24f22e79975f',\n",
-       " '_updatedAt': '2024-02-01T17:40:39.925Z',\n",
+       " '_self': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/https:%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F5eb29fff-931d-454e-b836-10ca68578899',\n",
+       " '_updatedAt': '2024-02-02T09:19:23.719Z',\n",
        " '_updatedBy': 'https://sandbox.bluebrainnexus.io/v1/realms/github/users/ssssarah'}"
       ]
      },
@@ -793,7 +793,7 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/6a541028-8a0f-4a95-82f8-3472af91372e',\n",
+       "{'id': 'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/31a7f009-e803-47f8-ac47-87237a4c8d9c',\n",
        " 'type': 'Dataset',\n",
        " 'contribution': [{'type': 'Contribution',\n",
        "   'agent': {'type': 'Person', 'name': 'Jane Doe'}},\n",
@@ -804,7 +804,7 @@
        "    'type': 'DiskStorage',\n",
        "    '_rev': 1}},\n",
        "  'contentSize': {'unitCode': 'bytes', 'value': 477},\n",
-       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F3d70ede3-50d9-46bb-ad5e-d02abe186a2d',\n",
+       "  'contentUrl': 'https://sandbox.bluebrainnexus.io/v1/files/github-users/ssssarah/https%3A%2F%2Fsandbox.bluebrainnexus.io%2Fv1%2Fresources%2Fgithub-users%2Fssssarah%2F_%2F948556c2-cc72-497a-9e17-9398c288137b',\n",
        "  'digest': {'algorithm': 'SHA-256',\n",
        "   'value': '789aa07948683fe036ac29811814a826b703b562f7d168eb70dee1fabde26859'},\n",
        "  'encodingFormat': 'text/tab-separated-values',\n",
@@ -2290,20 +2290,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
     "import requests \n",
     "\n",
-    "# TODO fix view definition, doesn't seem to work with filters, see if mapping is the problem\n",
     "payload = {\n",
     "    \"@type\": [\"View\", \"ElasticSearchView\"],\n",
     "    \"pipeline\": [{\n",
     "                \"name\": \"filterByType\",\n",
     "                \"config\": {\"types\": [\"http://schema.org/Person\"]}\n",
     "            }],\n",
-    "    \"mapping\": {}\n",
+    "    \"mapping\": {\n",
+    "        \"dynamic\": True,\n",
+    "        \"properties\": {\n",
+    "          \"@id\": {\n",
+    "            \"type\": \"keyword\"\n",
+    "          },\n",
+    "          \"@type\": {\n",
+    "            \"type\": \"keyword\"\n",
+    "          }\n",
+    "        }\n",
+    "    }\n",
     "}\n",
     "\n",
     "url = f\"{forge._store.endpoint}/views/{forge._store.bucket}\"\n",
@@ -2319,16 +2328,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/3d8ef57a-d12c-4fb8-b789-8e56af7625ef'"
+       "'https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/a9611b3e-3c85-487b-befc-415e347dd9a1'"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2347,15 +2356,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'Person'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n",
-      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'Dataset'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n"
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'http://schema.org/Dataset'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n",
+      "Submitted query: {'query': {'bool': {'filter': [{'term': {'@type': 'http://schema.org/Person'}}, {'term': {'_project': 'https://sandbox.bluebrainnexus.io/v1/projects/github-users/ssssarah'}}], 'must': [{'match': {'_deprecated': False}}], 'must_not': []}}, 'size': 100}\n"
      ]
     },
     {
@@ -2364,19 +2373,15 @@
        "(0, 0)"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result_1 = forge.search(\n",
-    "    {\"@type\": \"Person\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True\n",
-    ")\n",
+    "result_1 = forge.search({\"@type\": \"http://schema.org/Dataset\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True)\n",
     "\n",
-    "result_2 =  forge.search(\n",
-    "    {\"@type\": \"Dataset\"}, search_endpoint='elastic', view=view_id, cross_bucket=True, debug=True\n",
-    ")\n",
+    "result_2 =  forge.search({\"@type\": \"http://schema.org/Person\"}, search_endpoint='elastic', view=view_id, debug=True)\n",
     "\n",
     "len(result_1), len(result_2)"
    ]
@@ -2399,7 +2404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2408,235 +2413,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 80,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 81,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>type</th>\n",
-       "      <th>agent.type</th>\n",
-       "      <th>agent.gender.id</th>\n",
-       "      <th>agent.gender.type</th>\n",
-       "      <th>agent.gender.label</th>\n",
-       "      <th>agent.name</th>\n",
-       "      <th>distribution.type</th>\n",
-       "      <th>distribution.atLocation.type</th>\n",
-       "      <th>distribution.atLocation.store.id</th>\n",
-       "      <th>distribution.atLocation.store.type</th>\n",
-       "      <th>distribution.atLocation.store._rev</th>\n",
-       "      <th>distribution.contentSize.unitCode</th>\n",
-       "      <th>distribution.contentSize.value</th>\n",
-       "      <th>distribution.contentUrl</th>\n",
-       "      <th>distribution.digest.algorithm</th>\n",
-       "      <th>distribution.digest.value</th>\n",
-       "      <th>distribution.encodingFormat</th>\n",
-       "      <th>distribution.name</th>\n",
-       "      <th>name</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Association</td>\n",
-       "      <td>Person</td>\n",
-       "      <td>http://purl.obolibrary.org/obo/PATO_0000383</td>\n",
-       "      <td>LabeledOntologyEntity</td>\n",
-       "      <td>female</td>\n",
-       "      <td>Marie Curie</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>46.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...</td>\n",
-       "      <td>text/plain</td>\n",
-       "      <td>marie_curie.txt</td>\n",
-       "      <td>Curie Association</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Association</td>\n",
-       "      <td>Person</td>\n",
-       "      <td>http://purl.obolibrary.org/obo/PATO_0000384</td>\n",
-       "      <td>LabeledOntologyEntity</td>\n",
-       "      <td>male</td>\n",
-       "      <td>Albert Einstein</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>50.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...</td>\n",
-       "      <td>text/plain</td>\n",
-       "      <td>albert_einstein.txt</td>\n",
-       "      <td>Einstein Association</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Association</td>\n",
-       "      <td>Person</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Jane Doe</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                  id         type agent.type  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
-       "\n",
-       "                               agent.gender.id      agent.gender.type  \\\n",
-       "0  http://purl.obolibrary.org/obo/PATO_0000383  LabeledOntologyEntity   \n",
-       "1  http://purl.obolibrary.org/obo/PATO_0000384  LabeledOntologyEntity   \n",
-       "2                                          NaN                    NaN   \n",
-       "\n",
-       "  agent.gender.label       agent.name distribution.type  \\\n",
-       "0             female      Marie Curie      DataDownload   \n",
-       "1               male  Albert Einstein      DataDownload   \n",
-       "2                NaN         Jane Doe               NaN   \n",
-       "\n",
-       "  distribution.atLocation.type  \\\n",
-       "0                     Location   \n",
-       "1                     Location   \n",
-       "2                          NaN   \n",
-       "\n",
-       "                    distribution.atLocation.store.id  \\\n",
-       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
-       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
-       "2                                                NaN   \n",
-       "\n",
-       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
-       "0                        DiskStorage                                 1.0   \n",
-       "1                        DiskStorage                                 1.0   \n",
-       "2                                NaN                                 NaN   \n",
-       "\n",
-       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
-       "0                             bytes                            46.0   \n",
-       "1                             bytes                            50.0   \n",
-       "2                               NaN                             NaN   \n",
-       "\n",
-       "                             distribution.contentUrl  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
-       "2                                                NaN   \n",
-       "\n",
-       "  distribution.digest.algorithm  \\\n",
-       "0                       SHA-256   \n",
-       "1                       SHA-256   \n",
-       "2                           NaN   \n",
-       "\n",
-       "                           distribution.digest.value  \\\n",
-       "0  e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...   \n",
-       "1  91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...   \n",
-       "2                                                NaN   \n",
-       "\n",
-       "  distribution.encodingFormat    distribution.name                  name  \n",
-       "0                  text/plain      marie_curie.txt     Curie Association  \n",
-       "1                  text/plain  albert_einstein.txt  Einstein Association  \n",
-       "2                         NaN                  NaN                   NaN  "
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2646,88 +2450,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 84,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: []\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 86,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -2743,7 +2486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2752,228 +2495,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 88,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 89,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>type</th>\n",
-       "      <th>agent.type</th>\n",
-       "      <th>agent.gender.id</th>\n",
-       "      <th>agent.gender.type</th>\n",
-       "      <th>agent.gender.label</th>\n",
-       "      <th>agent.name</th>\n",
-       "      <th>distribution.type</th>\n",
-       "      <th>distribution.atLocation.type</th>\n",
-       "      <th>distribution.atLocation.store.id</th>\n",
-       "      <th>distribution.atLocation.store.type</th>\n",
-       "      <th>distribution.atLocation.store._rev</th>\n",
-       "      <th>distribution.contentSize.unitCode</th>\n",
-       "      <th>distribution.contentSize.value</th>\n",
-       "      <th>distribution.contentUrl</th>\n",
-       "      <th>distribution.digest.algorithm</th>\n",
-       "      <th>distribution.digest.value</th>\n",
-       "      <th>distribution.encodingFormat</th>\n",
-       "      <th>distribution.name</th>\n",
-       "      <th>name</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Association</td>\n",
-       "      <td>Person</td>\n",
-       "      <td>http://purl.obolibrary.org/obo/PATO_0000383</td>\n",
-       "      <td>LabeledOntologyEntity</td>\n",
-       "      <td>female</td>\n",
-       "      <td>Marie Curie</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>46.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...</td>\n",
-       "      <td>text/plain</td>\n",
-       "      <td>marie_curie.txt</td>\n",
-       "      <td>Curie Association</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Association</td>\n",
-       "      <td>Person</td>\n",
-       "      <td>http://purl.obolibrary.org/obo/PATO_0000384</td>\n",
-       "      <td>LabeledOntologyEntity</td>\n",
-       "      <td>male</td>\n",
-       "      <td>Albert Einstein</td>\n",
-       "      <td>DataDownload</td>\n",
-       "      <td>Location</td>\n",
-       "      <td>https://bluebrain.github.io/nexus/vocabulary/d...</td>\n",
-       "      <td>DiskStorage</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>bytes</td>\n",
-       "      <td>50.0</td>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/files/git...</td>\n",
-       "      <td>SHA-256</td>\n",
-       "      <td>91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...</td>\n",
-       "      <td>text/plain</td>\n",
-       "      <td>albert_einstein.txt</td>\n",
-       "      <td>Einstein Association</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Association</td>\n",
-       "      <td>Person</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>Jane Doe</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                  id         type agent.type  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...  Association     Person   \n",
-       "\n",
-       "                               agent.gender.id      agent.gender.type  \\\n",
-       "0  http://purl.obolibrary.org/obo/PATO_0000383  LabeledOntologyEntity   \n",
-       "1  http://purl.obolibrary.org/obo/PATO_0000384  LabeledOntologyEntity   \n",
-       "2                                          NaN                    NaN   \n",
-       "\n",
-       "  agent.gender.label       agent.name distribution.type  \\\n",
-       "0             female      Marie Curie      DataDownload   \n",
-       "1               male  Albert Einstein      DataDownload   \n",
-       "2                NaN         Jane Doe               NaN   \n",
-       "\n",
-       "  distribution.atLocation.type  \\\n",
-       "0                     Location   \n",
-       "1                     Location   \n",
-       "2                          NaN   \n",
-       "\n",
-       "                    distribution.atLocation.store.id  \\\n",
-       "0  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
-       "1  https://bluebrain.github.io/nexus/vocabulary/d...   \n",
-       "2                                                NaN   \n",
-       "\n",
-       "  distribution.atLocation.store.type  distribution.atLocation.store._rev  \\\n",
-       "0                        DiskStorage                                 1.0   \n",
-       "1                        DiskStorage                                 1.0   \n",
-       "2                                NaN                                 NaN   \n",
-       "\n",
-       "  distribution.contentSize.unitCode  distribution.contentSize.value  \\\n",
-       "0                             bytes                            46.0   \n",
-       "1                             bytes                            50.0   \n",
-       "2                               NaN                             NaN   \n",
-       "\n",
-       "                             distribution.contentUrl  \\\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
-       "1  https://sandbox.bluebrainnexus.io/v1/files/git...   \n",
-       "2                                                NaN   \n",
-       "\n",
-       "  distribution.digest.algorithm  \\\n",
-       "0                       SHA-256   \n",
-       "1                       SHA-256   \n",
-       "2                           NaN   \n",
-       "\n",
-       "                           distribution.digest.value  \\\n",
-       "0  e0fe65f725bf28fe2b88c7bafb51fb5ef1df0ab14c68a3...   \n",
-       "1  91a5ce5c84dc5bead730a4b49d0698b4aaef4bc06ce164...   \n",
-       "2                                                NaN   \n",
-       "\n",
-       "  distribution.encodingFormat    distribution.name                  name  \n",
-       "0                  text/plain      marie_curie.txt     Curie Association  \n",
-       "1                  text/plain  albert_einstein.txt  Einstein Association  \n",
-       "2                         NaN                  NaN                   NaN  "
-      ]
-     },
-     "execution_count": 90,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -3010,7 +2552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3020,7 +2562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3030,7 +2572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3039,166 +2581,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<action> _register_one\n",
-      "<succeeded> True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.register(association)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "    id: \"\"\n",
-      "    type:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "    }\n",
-      "    annotation:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "        type: Annotation\n",
-      "        hasBody:\n",
-      "        {\n",
-      "            id: \"\"\n",
-      "            type:\n",
-      "            {\n",
-      "                id: \"\"\n",
-      "            }\n",
-      "            label: \"\"\n",
-      "            note: \"\"\n",
-      "        }\n",
-      "        hasTarget:\n",
-      "        {\n",
-      "            id: \"\"\n",
-      "            type: AnnotationTarget\n",
-      "        }\n",
-      "        note: \"\"\n",
-      "    }\n",
-      "    brainLocation:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "        type: BrainLocation\n",
-      "        atlasSpatialReferenceSystem:\n",
-      "        {\n",
-      "            id: \"\"\n",
-      "            type: AtlasSpatialReferenceSystem\n",
-      "        }\n",
-      "        brainRegion:\n",
-      "        {\n",
-      "            id: \"\"\n",
-      "            label: \"\"\n",
-      "        }\n",
-      "        coordinatesInBrainAtlas:\n",
-      "        {\n",
-      "            id: \"\"\n",
-      "            valueX: 0.0\n",
-      "            valueY: 0.0\n",
-      "            valueZ: 0.0\n",
-      "        }\n",
-      "        coordinatesInSlice:\n",
-      "        {\n",
-      "            spatialReferenceSystem:\n",
-      "            {\n",
-      "                id: \"\"\n",
-      "                type: SpatialReferenceSystem\n",
-      "            }\n",
-      "            valueX: 0.0\n",
-      "            valueY: 0.0\n",
-      "            valueZ: 0.0\n",
-      "        }\n",
-      "        distanceToBoundary:\n",
-      "        {\n",
-      "            boundary:\n",
-      "            {\n",
-      "                id: \"\"\n",
-      "                label: \"\"\n",
-      "            }\n",
-      "            distance:\n",
-      "            {\n",
-      "                unitCode: \"\"\n",
-      "                value:\n",
-      "                [\n",
-      "                    0.0\n",
-      "                    0\n",
-      "                ]\n",
-      "            }\n",
-      "        }\n",
-      "        layer:\n",
-      "        {\n",
-      "            id: \"\"\n",
-      "            label: \"\"\n",
-      "        }\n",
-      "        longitudinalAxis:\n",
-      "        [\n",
-      "            Dorsal\n",
-      "            Ventral\n",
-      "        ]\n",
-      "        positionInLayer:\n",
-      "        [\n",
-      "            Deep\n",
-      "            Superficial\n",
-      "        ]\n",
-      "    }\n",
-      "    contribution:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "    }\n",
-      "    distribution:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "        type: DataDownload\n",
-      "        contentSize:\n",
-      "        {\n",
-      "            unitCode: \"\"\n",
-      "            value:\n",
-      "            [\n",
-      "                0.0\n",
-      "                0\n",
-      "            ]\n",
-      "        }\n",
-      "        digest:\n",
-      "        {\n",
-      "            algorithm: \"\"\n",
-      "            value: \"\"\n",
-      "        }\n",
-      "        encodingFormat: \"\"\n",
-      "        license: \"\"\n",
-      "        name: \"\"\n",
-      "    }\n",
-      "    objectOfStudy:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "        type: ObjectOfStudy\n",
-      "    }\n",
-      "    releaseDate: 9999-12-31T00:00:00\n",
-      "    subject:\n",
-      "    {\n",
-      "        id: \"\"\n",
-      "        type: Subject\n",
-      "    }\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.template(\"Dataset\") # Templates help know which property to use when writing a query to serach for a given type"
    ]
@@ -3215,7 +2611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3231,7 +2627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3240,131 +2636,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 98,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 99,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "    id: https://sandbox.bluebrainnexus.io/v1/resources/github-users/ssssarah/_/7d0ba247-cff4-4292-b2d8-1fd1f8bd5159\n",
-      "    contributor: t1771\n",
-      "    name: John Smith\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>contributor</th>\n",
-       "      <th>name</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>t1771</td>\n",
-       "      <td>John Smith</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>t1772</td>\n",
-       "      <td>Jane Doe</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>t1836</td>\n",
-       "      <td>Jane Doe</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                  id contributor        name\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...       t1771  John Smith\n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...       t1772    Jane Doe\n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...       t1836    Jane Doe"
-      ]
-     },
-     "execution_count": 101,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -3379,42 +2680,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitted query:\n",
-      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
-      "   PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
-      "   PREFIX dcterms: <http://purl.org/dc/terms/>\n",
-      "   PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
-      "   PREFIX nsg: <https://neuroshapes.org/>\n",
-      "   PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
-      "   PREFIX prov: <http://www.w3.org/ns/prov#>\n",
-      "   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-      "   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
-      "   PREFIX schema: <http://schema.org/>\n",
-      "   PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
-      "   PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
-      "   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
-      "   PREFIX vann: <http://purl.org/vocab/vann/>\n",
-      "   PREFIX void: <http://rdfs.org/ns/void#>\n",
-      "   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
-      "   PREFIX : <https://neuroshapes.org/>\n",
-      "   \n",
-      "       SELECT ?id ?name ?contributor\n",
-      "       WHERE {\n",
-      "           ?id a schema:Dataset ;\n",
-      "           nsg:contribution/prov:agent ?contributor.\n",
-      "           ?contributor schema:name ?name.\n",
-      "       }\n",
-      "     LIMIT 3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "resources = forge.sparql(query, limit=3, debug=True)"
    ]
@@ -3431,7 +2699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3467,44 +2735,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitted query:\n",
-      "   \n",
-      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
-      "      PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
-      "      PREFIX dcterms: <http://purl.org/dc/terms/>\n",
-      "      PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
-      "      PREFIX nsg: <https://neuroshapes.org/>\n",
-      "      PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
-      "      PREFIX prov: <http://www.w3.org/ns/prov#>\n",
-      "      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-      "      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
-      "      PREFIX schema: <http://schema.org/>\n",
-      "      PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
-      "      PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
-      "      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
-      "      PREFIX vann: <http://purl.org/vocab/vann/>\n",
-      "      PREFIX void: <http://rdfs.org/ns/void#>\n",
-      "      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
-      "      PREFIX : <https://neuroshapes.org/>\n",
-      "      SELECT ?id ?name\n",
-      "      WHERE {\n",
-      "          ?id a schema:Dataset ;\n",
-      "          nsg:contribution/prov:agent ?contributor.\n",
-      "          ?contributor schema:name ?name.\n",
-      "      }\n",
-      "      ORDER BY ?id\n",
-      "      LIMIT 3\n",
-      "      OFFSET 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# it is recommended to set 'rewrite' to 'False' to prevent the sparql query rewriting when a syntactically correct SPARQL query is provided.\n",
     "resources = forge.sparql(query, rewrite=False, limit=3, offset=1, debug=True) "
@@ -3512,126 +2745,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 105,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 106,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "kgforge.core.resource.Resource"
-      ]
-     },
-     "execution_count": 107,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>name</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Jane Doe</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>John Smith</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://sandbox.bluebrainnexus.io/v1/resources...</td>\n",
-       "      <td>Jane Doe</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                  id        name\n",
-       "0  https://sandbox.bluebrainnexus.io/v1/resources...    Jane Doe\n",
-       "1  https://sandbox.bluebrainnexus.io/v1/resources...  John Smith\n",
-       "2  https://sandbox.bluebrainnexus.io/v1/resources...    Jane Doe"
-      ]
-     },
-     "execution_count": 108,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -3654,7 +2797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3688,42 +2831,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitted query:\n",
-      "   \n",
-      "      PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
-      "      PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
-      "      PREFIX dcterms: <http://purl.org/dc/terms/>\n",
-      "      PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
-      "      PREFIX nsg: <https://neuroshapes.org/>\n",
-      "      PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
-      "      PREFIX prov: <http://www.w3.org/ns/prov#>\n",
-      "      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-      "      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
-      "      PREFIX schema: <http://schema.org/>\n",
-      "      PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
-      "      PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
-      "      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
-      "      PREFIX vann: <http://purl.org/vocab/vann/>\n",
-      "      PREFIX void: <http://rdfs.org/ns/void#>\n",
-      "      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
-      "      PREFIX : <https://neuroshapes.org/>\n",
-      "      SELECT ?id ?name\n",
-      "      WHERE {\n",
-      "          ?id a schema:Dataset ;\n",
-      "          nsg:contribution/prov:agent ?contributor.\n",
-      "          ?contributor schema:name ?name.\n",
-      "      }\n",
-      "      ORDER BY ?id\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "resources = forge.sparql(query_without_limit, rewrite=False, limit=None, offset=None, debug=True)"
@@ -3731,20 +2841,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "58"
-      ]
-     },
-     "execution_count": 111,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
@@ -3759,7 +2858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3775,61 +2874,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Submitted query:\n",
-      "   PREFIX dc: <http://purl.org/dc/elements/1.1/>\n",
-      "   PREFIX dcat: <http://www.w3.org/ns/dcat#>\n",
-      "   PREFIX dcterms: <http://purl.org/dc/terms/>\n",
-      "   PREFIX mba: <http://api.brain-map.org/api/v2/data/Structure/>\n",
-      "   PREFIX nsg: <https://neuroshapes.org/>\n",
-      "   PREFIX owl: <http://www.w3.org/2002/07/owl#>\n",
-      "   PREFIX prov: <http://www.w3.org/ns/prov#>\n",
-      "   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-      "   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n",
-      "   PREFIX schema: <http://schema.org/>\n",
-      "   PREFIX sh: <http://www.w3.org/ns/shacl#>\n",
-      "   PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>\n",
-      "   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>\n",
-      "   PREFIX vann: <http://purl.org/vocab/vann/>\n",
-      "   PREFIX void: <http://rdfs.org/ns/void#>\n",
-      "   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
-      "   PREFIX : <https://neuroshapes.org/>\n",
-      "   \n",
-      "       SELECT ?id ?name ?contributor\n",
-      "       WHERE {\n",
-      "           ?id a schema:Dataset ;\n",
-      "           nsg:contribution/prov:agent ?contributor.\n",
-      "           ?contributor schema:name ?name.\n",
-      "       }\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "resources = forge.sparql(query_without_context, limit=None, debug=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "58"
-      ]
-     },
-     "execution_count": 114,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
@@ -3854,7 +2910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3864,7 +2920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3874,7 +2930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3883,18 +2939,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<action> _register_one\n",
-      "<succeeded> True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.register(association)"
    ]
@@ -3909,7 +2956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3932,7 +2979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3942,126 +2989,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 121,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 122,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(resources)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "kgforge.core.resource.Resource"
-      ]
-     },
-     "execution_count": 123,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(resources[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>name</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
-       "      <td>AA1543</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
-       "      <td>AA1542</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://bbp.epfl.ch/neurosciencegraph/data/neu...</td>\n",
-       "      <td>AA1544</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                  id    name\n",
-       "0  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1543\n",
-       "1  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1542\n",
-       "2  https://bbp.epfl.ch/neurosciencegraph/data/neu...  AA1544"
-      ]
-     },
-     "execution_count": 124,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.as_dataframe(resources)"
    ]
@@ -4084,7 +3041,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4093,29 +3050,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "associations.tsv\n",
-      "my_data.xwz\n",
-      "my_data_derived.txt\n",
-      "persons-with-id.csv\n",
-      "persons.csv\n",
-      "tfidfvectorizer_model_schemaorg_linking\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! ls -p ../../data | egrep -v /$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4124,7 +3068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4133,25 +3077,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<action> _register_one\n",
-      "<succeeded> True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "forge.register(association)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4166,7 +3101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4176,7 +3111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4187,66 +3122,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "total 2736\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Oct 20 10:54 associations.tsv\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Nov 23 15:10 associations.tsv.20231123151033\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Nov 23 15:10 associations.tsv.20231123151035\n",
-      "-rw-r--r--  1 mouffok  10067     477 Nov 23 15:41 associations.tsv.20231123154107\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:20 associations.tsv.20231127142049\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:20 associations.tsv.20231127142050\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Nov 27 14:24 associations.tsv.20231127142458\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Dec  5 15:37 associations.tsv.20231205153754\n",
-      "-rw-r--r--@ 1 mouffok  10067     477 Dec  5 15:44 associations.tsv.20231205154444\n",
-      "-rw-r--r--  1 mouffok  10067     477 Feb  1 18:40 associations.tsv.20240201184048\n",
-      "-rw-r--r--@ 1 mouffok  10067      16 Oct 20 10:54 my_data.xwz\n",
-      "-rw-r--r--  1 mouffok  10067      16 Nov 23 15:41 my_data.xwz.20231123154107\n",
-      "-rw-r--r--@ 1 mouffok  10067      16 Nov 27 14:24 my_data.xwz.20231127142458\n",
-      "-rw-r--r--@ 1 mouffok  10067      16 Dec  5 15:37 my_data.xwz.20231205153754\n",
-      "-rw-r--r--@ 1 mouffok  10067      16 Dec  5 15:44 my_data.xwz.20231205154444\n",
-      "-rw-r--r--  1 mouffok  10067      16 Feb  1 18:40 my_data.xwz.20240201184048\n",
-      "-rw-r--r--@ 1 mouffok  10067      24 Oct 20 10:54 my_data_derived.txt\n",
-      "-rw-r--r--  1 mouffok  10067      24 Nov 23 15:41 my_data_derived.txt.20231123154107\n",
-      "-rw-r--r--@ 1 mouffok  10067      24 Nov 27 14:24 my_data_derived.txt.20231127142458\n",
-      "-rw-r--r--@ 1 mouffok  10067      24 Dec  5 15:37 my_data_derived.txt.20231205153754\n",
-      "-rw-r--r--@ 1 mouffok  10067      24 Dec  5 15:44 my_data_derived.txt.20231205154444\n",
-      "-rw-r--r--  1 mouffok  10067      24 Feb  1 18:40 my_data_derived.txt.20240201184048\n",
-      "-rw-r--r--@ 1 mouffok  10067     126 Oct 20 10:54 persons-with-id.csv\n",
-      "-rw-r--r--  1 mouffok  10067     126 Nov 23 15:41 persons-with-id.csv.20231123154107\n",
-      "-rw-r--r--@ 1 mouffok  10067     126 Nov 27 14:24 persons-with-id.csv.20231127142458\n",
-      "-rw-r--r--@ 1 mouffok  10067     126 Dec  5 15:37 persons-with-id.csv.20231205153754\n",
-      "-rw-r--r--@ 1 mouffok  10067     126 Dec  5 15:44 persons-with-id.csv.20231205154444\n",
-      "-rw-r--r--  1 mouffok  10067     126 Feb  1 18:40 persons-with-id.csv.20240201184048\n",
-      "-rw-r--r--@ 1 mouffok  10067      52 Oct 20 10:54 persons.csv\n",
-      "-rw-r--r--@ 1 mouffok  10067      52 Nov 23 15:10 persons.csv.20231123151035\n",
-      "-rw-r--r--  1 mouffok  10067      52 Nov 23 15:41 persons.csv.20231123154107\n",
-      "-rw-r--r--@ 1 mouffok  10067      52 Nov 27 14:20 persons.csv.20231127142050\n",
-      "-rw-r--r--@ 1 mouffok  10067      52 Nov 27 14:24 persons.csv.20231127142458\n",
-      "-rw-r--r--@ 1 mouffok  10067      52 Dec  5 15:37 persons.csv.20231205153754\n",
-      "-rw-r--r--@ 1 mouffok  10067      52 Dec  5 15:44 persons.csv.20231205154444\n",
-      "-rw-r--r--  1 mouffok  10067      52 Feb  1 18:40 persons.csv.20240201184048\n",
-      "-rw-r--r--@ 1 mouffok  10067  204848 Oct 20 10:54 tfidfvectorizer_model_schemaorg_linking\n",
-      "-rw-r--r--  1 mouffok  10067  204848 Nov 23 15:41 tfidfvectorizer_model_schemaorg_linking.20231123154107\n",
-      "-rw-r--r--@ 1 mouffok  10067  204848 Nov 27 14:24 tfidfvectorizer_model_schemaorg_linking.20231127142458\n",
-      "-rw-r--r--@ 1 mouffok  10067  204848 Dec  5 15:37 tfidfvectorizer_model_schemaorg_linking.20231205153754\n",
-      "-rw-r--r--@ 1 mouffok  10067  204848 Dec  5 15:44 tfidfvectorizer_model_schemaorg_linking.20231205154444\n",
-      "-rw-r--r--  1 mouffok  10067  204848 Feb  1 18:40 tfidfvectorizer_model_schemaorg_linking.20240201184048\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! ls -l ./downloaded/"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/kgforge/core/archetypes/dataset_store.py
+++ b/kgforge/core/archetypes/dataset_store.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
-from abc import abstractmethod, ABC
+from abc import abstractmethod
 
 from typing import Optional, Union, List, Type, Dict
 from kgforge.core.resource import Resource
@@ -77,12 +77,14 @@ class DatasetStore(ReadOnlyStore):
         return list(self.model.mappings(self.model.source, False).keys())
 
     def search(
-            self, filters: List[Union[Dict, Filter]], resolvers: Optional[List[Resolver]] = None,
+            self, *filters: Union[Dict, Filter],
+            resolvers: Optional[List[Resolver]] = None,
             **params
     ) -> Optional[List[Resource]]:
-        """Search within the database.
-        :param map: bool
         """
+        Search within the database.
+        """
+        filters = list(filters)
         unmapped_resources = self._search(filters, resolvers, **params)
 
         if not params.pop('map', True):
@@ -102,12 +104,10 @@ class DatasetStore(ReadOnlyStore):
             self, query: str, debug: bool = False, limit: Optional[int] = None,
             offset: Optional[int] = None, **params
     ) -> Optional[Union[List[Resource], Resource]]:
-        """Use SPARQL within the database.
-        :param map: bool
         """
-        unmapped_resources = super(ReadOnlyStore, self).sparql(
-            query, debug, limit, offset, **params
-        )
+        Use SPARQL within the database.
+        """
+        unmapped_resources = super().sparql(query, debug, limit, offset, **params)
 
         if not params.pop('map', True):
             return unmapped_resources

--- a/kgforge/core/archetypes/read_only_store.py
+++ b/kgforge/core/archetypes/read_only_store.py
@@ -238,10 +238,10 @@ class ReadOnlyStore(ABC):
         if debug:
             SPARQLQueryBuilder.debug_query(qr)
 
-        return self._sparql(qr)
+        return self._sparql(qr, endpoint=params.get("endpoint", None))
 
     @abstractmethod
-    def _sparql(self, query: str) -> Optional[Union[List[Resource], Resource]]:
+    def _sparql(self, query: str, endpoint: Optional[str]) -> Optional[Union[List[Resource], Resource]]:
         # POLICY Should notify of failures with exception QueryingError including a message.
         # POLICY Resource _store_metadata should not be set (default is None).
         # POLICY Resource _synchronized should not be set (default is False).

--- a/kgforge/core/archetypes/read_only_store.py
+++ b/kgforge/core/archetypes/read_only_store.py
@@ -241,7 +241,7 @@ class ReadOnlyStore(ABC):
         return self._sparql(qr, view=params.get("view", None))
 
     @abstractmethod
-    def _sparql(self, query: str, endpoint: Optional[str]) -> Optional[Union[List[Resource], Resource]]:
+    def _sparql(self, query: str, view: Optional[str]) -> Optional[Union[List[Resource], Resource]]:
         # POLICY Should notify of failures with exception QueryingError including a message.
         # POLICY Resource _store_metadata should not be set (default is None).
         # POLICY Resource _synchronized should not be set (default is False).

--- a/kgforge/core/archetypes/read_only_store.py
+++ b/kgforge/core/archetypes/read_only_store.py
@@ -238,7 +238,7 @@ class ReadOnlyStore(ABC):
         if debug:
             SPARQLQueryBuilder.debug_query(qr)
 
-        return self._sparql(qr, endpoint=params.get("endpoint", None))
+        return self._sparql(qr, view=params.get("view", None))
 
     @abstractmethod
     def _sparql(self, query: str, endpoint: Optional[str]) -> Optional[Union[List[Resource], Resource]]:

--- a/kgforge/core/archetypes/read_only_store.py
+++ b/kgforge/core/archetypes/read_only_store.py
@@ -182,7 +182,7 @@ class ReadOnlyStore(ABC):
 
     @abstractmethod
     def search(
-            self, resolvers: Optional[List[Resolver]], filters: List[Union[Dict, Filter]], **params
+            self, resolvers: Optional[List[Resolver]], *filters: Union[Dict, Filter], **params
     ) -> List[Resource]:
 
         # Positional arguments in 'filters' are instances of type Filter from wrappings/paths.py

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -253,7 +253,7 @@ class Store(ReadOnlyStore):
         if debug:
             ESQueryBuilder.debug_query(query_dict)
 
-        return self._elastic(json.dumps(query_dict), endpoint=params.get("endpoint", None))
+        return self._elastic(json.dumps(query_dict), view=params.get("view", None))
 
     @abstractmethod
     def _elastic(self, query: str, endpoint: Optional[str]) -> Optional[Union[List[Resource], Resource]]:

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -256,7 +256,7 @@ class Store(ReadOnlyStore):
         return self._elastic(json.dumps(query_dict), view=params.get("view", None))
 
     @abstractmethod
-    def _elastic(self, query: str, endpoint: Optional[str]) -> Optional[Union[List[Resource], Resource]]:
+    def _elastic(self, query: str, view: Optional[str]) -> Optional[Union[List[Resource], Resource]]:
         # POLICY Should notify of failures with exception QueryingError including a message.
         # POLICY Resource _store_metadata should not be set (default is None).
         # POLICY Resource _synchronized should not be set (default is False).

--- a/kgforge/core/archetypes/store.py
+++ b/kgforge/core/archetypes/store.py
@@ -32,7 +32,7 @@ from kgforge.core.commons.exceptions import (
     UpdatingError,
     UploadingError
 )
-from kgforge.core.commons.execution import not_supported, run
+from kgforge.core.commons.execution import run
 
 
 class Store(ReadOnlyStore):
@@ -239,7 +239,8 @@ class Store(ReadOnlyStore):
         ...
 
     def elastic(
-            self, query: str, debug: bool, limit: int = DEFAULT_LIMIT, offset: int = DEFAULT_OFFSET
+            self, query: str, debug: bool, limit: int = DEFAULT_LIMIT, offset: int = DEFAULT_OFFSET,
+            **params
     ) -> List[Resource]:
         query_dict = json.loads(query)
 
@@ -252,10 +253,10 @@ class Store(ReadOnlyStore):
         if debug:
             ESQueryBuilder.debug_query(query_dict)
 
-        return self._elastic(json.dumps(query_dict))
+        return self._elastic(json.dumps(query_dict), endpoint=params.get("endpoint", None))
 
     @abstractmethod
-    def _elastic(self, query: str) -> Optional[Union[List[Resource], Resource]]:
+    def _elastic(self, query: str, endpoint: Optional[str]) -> Optional[Union[List[Resource], Resource]]:
         # POLICY Should notify of failures with exception QueryingError including a message.
         # POLICY Resource _store_metadata should not be set (default is None).
         # POLICY Resource _synchronized should not be set (default is False).

--- a/kgforge/core/commons/es_query_builder.py
+++ b/kgforge/core/commons/es_query_builder.py
@@ -37,7 +37,7 @@ elasticsearch_operator_range_map = {
 class ESQueryBuilder(QueryBuilder):
     @staticmethod
     def build(
-        schema: Dict,
+        schema: Optional[Dict],
         resolvers: Optional[List["Resolver"]],
         context: Context,
         filters: List[Filter],

--- a/kgforge/core/commons/query_builder.py
+++ b/kgforge/core/commons/query_builder.py
@@ -28,7 +28,7 @@ class QueryBuilder(ABC):
     @staticmethod
     @abstractmethod
     def build(
-        schema: Any,
+        schema: Optional[Dict],
         resolvers: Optional[List["Resolver"]],
         context: Context,
         filters: List[Filter],

--- a/kgforge/core/commons/sparql_query_builder.py
+++ b/kgforge/core/commons/sparql_query_builder.py
@@ -120,7 +120,7 @@ class SPARQLQueryBuilder(QueryBuilder):
 
     @staticmethod
     def build(
-            schema: Dict,
+            schema: Optional[Dict],
             resolvers: Optional[List[Resolver]],
             context: Context,
             filters: List[Filter],

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -643,6 +643,12 @@ class KnowledgeGraphForge:
         :param params: a dictionary of parameters
         :return: List[Resource]
         """
+
+        if "filters" in params:
+            raise ValueError(
+                "A 'filters' key was provided as params. Filters should be provided as iterable."
+            )
+
         resolvers = (
             list(self._resolvers.values()) if self._resolvers is not None else None
         )

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -644,11 +644,6 @@ class KnowledgeGraphForge:
         :return: List[Resource]
         """
 
-        if "filters" in params:
-            raise ValueError(
-                "A 'filters' key was provided as params. Filters should be provided as iterable."
-            )
-
         resolvers = (
             list(self._resolvers.values()) if self._resolvers is not None else None
         )

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -676,6 +676,7 @@ class KnowledgeGraphForge:
         debug: bool = False,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        **params
     ) -> List[Resource]:
         """
         Search for resources using an ElasticSearch DSL query. See ElasticSearch DSL docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html.
@@ -686,7 +687,7 @@ class KnowledgeGraphForge:
         :param offset: how many results to skip from the first one
         :return: List[Resource]
         """
-        return self._store.elastic(query, debug, limit, offset)
+        return self._store.elastic(query, debug, limit, offset, **params)
 
     @catch
     def download(

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -820,7 +820,11 @@ class BlueBrainNexus(Store):
     def get_context_prefix_vocab(self) -> Tuple[Optional[Dict], Optional[Dict], Optional[str]]:
         return BlueBrainNexus.reformat_contexts(self.model_context(), self.service.metadata_context)
 
-    def _sparql(self, query: str, endpoint: str) -> List[Resource]:
+    def _sparql(self, query: str, view: str) -> List[Resource]:
+
+        endpoint = self.service.sparql_endpoint["endpoint"] \
+            if view is None \
+            else self.service.make_endpoint(view, endpoint_type="sparql")
 
         response = requests.post(
             endpoint,
@@ -834,10 +838,14 @@ class BlueBrainNexus(Store):
         context = self.model_context() or self.context
         return SPARQLQueryBuilder.build_resource_from_response(query, data, context)
 
-    def _elastic(self, query: str, endpoint: Optional[str]) -> List[Resource]:
+    def _elastic(self, query: str, view: Optional[str]) -> List[Resource]:
+
+        endpoint = self.service.elastic_endpoint["endpoint"] \
+            if view is None \
+            else self.service.make_endpoint(view, endpoint_type="elastic")
 
         response = requests.post(
-            self.service.elastic_endpoint["endpoint"] if endpoint is None else endpoint,
+            endpoint,
             data=query,
             headers=self.service.headers_elastic,
         )

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -623,9 +623,14 @@ class BlueBrainNexus(Store):
         # Querying.
 
     def search(
-            self, filters: List[Union[Dict, Filter]], resolvers: Optional[List[Resolver]],
+            self, *filters: Union[Dict, Filter], resolvers: Optional[List[Resolver]],
             **params
     ) -> List[Resource]:
+
+        if "filters" in params:
+            raise ValueError(
+                "A 'filters' key was provided as params. Filters should be provided as iterable."
+            )
 
         if self.model_context() is None:
             raise ValueError("context model missing")

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -707,7 +707,7 @@ class BlueBrainNexus(Store):
             )
             # support @id and @type
             resources = self.sparql(
-                query, debug=debug, limit=limit, offset=offset, endpoint=params.get("endpoint", None)
+                query, debug=debug, limit=limit, offset=offset, view=params.get("view", None)
             )
             params_retrieve = copy.deepcopy(self.service.params.get("retrieve", {}))
             params_retrieve['retrieve_source'] = retrieve_source
@@ -801,7 +801,7 @@ class BlueBrainNexus(Store):
 
             return self.elastic(
                 json.dumps(query), debug=debug, limit=limit, offset=offset,
-                endpoint=params.get("endpoint", None)
+                view=params.get("view", None)
             )
 
     @staticmethod  # for testing

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -198,10 +198,10 @@ class DemoStore(Store):
     def _deprecate_many(self, resources: List[Resource]) -> None:
         raise not_supported()
 
-    def _sparql(self, query: str, endpoint: Optional[str]) -> List[Resource]:
+    def _sparql(self, query: str, view: Optional[str]) -> List[Resource]:
         raise not_supported()
 
-    def _elastic(self, query: str, endpoint: Optional[str]) -> List[Resource]:
+    def _elastic(self, query: str, view: Optional[str]) -> List[Resource]:
         raise not_supported()
 
     def _freeze_many(self, resources: List[Resource]) -> None:

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -156,10 +156,10 @@ class DemoStore(Store):
         records = self.service.find(conditions)
         return [_to_resource(x) for x in records]
 
-    def _sparql(self, query: str) -> Optional[Union[List[Resource], Resource]]:
+    def _sparql(self, query: str, endpoint: str) -> Optional[Union[List[Resource], Resource]]:
         not_supported()
 
-    def _elastic(self, query: str) -> Optional[Union[List[Resource], Resource]]:
+    def _elastic(self, query: str, endpoint: str) -> Optional[Union[List[Resource], Resource]]:
         not_supported()
 
     # Utils.

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -82,8 +82,10 @@ class DemoStore(Store):
 
     # C[R]UD.
 
-    def retrieve(self, id_: str, version: Optional[Union[int, str]],
-                 cross_bucket: bool, **params) -> Optional[Resource]:
+    def retrieve(
+            self, id_: str, version: Optional[Union[int, str]],
+            cross_bucket: bool = False, **params
+    ) -> Optional[Resource]:
         if cross_bucket:
             raise not_supported(("cross_bucket", True))
         try:
@@ -157,10 +159,10 @@ class DemoStore(Store):
         return [_to_resource(x) for x in records]
 
     def _sparql(self, query: str, endpoint: str) -> Optional[Union[List[Resource], Resource]]:
-        not_supported()
+        raise not_supported()
 
     def _elastic(self, query: str, endpoint: str) -> Optional[Union[List[Resource], Resource]]:
-        not_supported()
+        raise not_supported()
 
     # Utils.
 
@@ -196,10 +198,10 @@ class DemoStore(Store):
     def _deprecate_many(self, resources: List[Resource]) -> None:
         raise not_supported()
 
-    def _sparql(self, query: str) -> List[Resource]:
+    def _sparql(self, query: str, endpoint: Optional[str]) -> List[Resource]:
         raise not_supported()
 
-    def _elastic(self, query: str) -> List[Resource]:
+    def _elastic(self, query: str, endpoint: Optional[str]) -> List[Resource]:
         raise not_supported()
 
     def _freeze_many(self, resources: List[Resource]) -> None:

--- a/kgforge/specializations/stores/demo_store.py
+++ b/kgforge/specializations/stores/demo_store.py
@@ -139,7 +139,7 @@ class DemoStore(Store):
     # Querying.
 
     def search(
-            self, filters: List[Union[Dict, Filter]], resolvers: Optional[List[Resolver]], **params
+            self, *filters: Union[Dict, Filter], resolvers: Optional[List[Resolver]], **params
     ) -> List[Resource]:
 
         cross_bucket = params.get("cross_bucket", None)

--- a/kgforge/specializations/stores/nexus/service.py
+++ b/kgforge/specializations/stores/nexus/service.py
@@ -192,11 +192,11 @@ class Service:
         )
 
         self.sparql_endpoint = {
-            "endpoint": self.make_endpoint(sparql_view, "sparql")
+            "endpoint": self.make_endpoint(sparql_view, Service.SPARQL_ENDPOINT_TYPE)
         }
 
         self.elastic_endpoint = {
-            "endpoint": self.make_endpoint(elastic_view, "_search")
+            "endpoint": self.make_endpoint(elastic_view, Service.ELASTIC_ENDPOINT_TYPE)
         }
 
         self.elastic_endpoint["view"] = LazyAction(
@@ -214,16 +214,33 @@ class Service:
         except RuntimeError:
             pass
 
-    def make_endpoint(self, view, endpoint_type, organisation=None, project=None):
+    @staticmethod
+    def make_query_endpoint(base, view, endpoint_type, organisation, project) -> str:
+
+        if endpoint_type == Service.SPARQL_ENDPOINT_TYPE:
+            last_url_component = "sparql"
+        elif endpoint_type == Service.ELASTIC_ENDPOINT_TYPE:
+            last_url_component = "_search"
+        else:
+            raise ValueError(f"Unknown endpoint type {endpoint_type}")
+
         return "/".join(
             (
-                self.endpoint,
+                base,
                 "views",
-                quote_plus(organisation or self.organisation),
-                quote_plus(project or self.project),
+                quote_plus(organisation),
+                quote_plus(project),
                 quote_plus(view),
-                endpoint_type,
-            )git
+                last_url_component,
+            )
+        )
+
+    def make_endpoint(self, view: str, endpoint_type: str):
+        return Service.make_query_endpoint(
+            base=self.endpoint, view=view,
+            endpoint_type=endpoint_type,
+            organisation=self.organisation,
+            project=self.project
         )
 
     def get_project_context(self) -> Dict:

--- a/kgforge/specializations/stores/nexus/service.py
+++ b/kgforge/specializations/stores/nexus/service.py
@@ -191,23 +191,12 @@ class Service:
             else None
         )
 
-        def make_endpoint(view, endpoint_type):
-            return "/".join(
-                (
-                    self.endpoint,
-                    "views",
-                    quote_plus(org),
-                    quote_plus(prj),
-                    quote_plus(view),
-                    endpoint_type,
-                )
-            )
         self.sparql_endpoint = {
-            "endpoint": make_endpoint(sparql_view, "sparql")
+            "endpoint": self.make_endpoint(sparql_view, "sparql")
         }
 
         self.elastic_endpoint = {
-            "endpoint": make_endpoint(elastic_view, "search")
+            "endpoint": self.make_endpoint(elastic_view, "search")
         }
 
         self.elastic_endpoint["view"] = LazyAction(
@@ -224,6 +213,18 @@ class Service:
             nest_asyncio.apply()
         except RuntimeError:
             pass
+
+    def make_endpoint(self, view, endpoint_type):
+        return "/".join(
+            (
+                self.endpoint,
+                "views",
+                quote_plus(self.organisation),
+                quote_plus(self.project),
+                quote_plus(view),
+                endpoint_type,
+            )
+        )
 
     def get_project_context(self) -> Dict:
         project_data = nexus.projects.fetch(self.organisation, self.project)

--- a/kgforge/specializations/stores/nexus/service.py
+++ b/kgforge/specializations/stores/nexus/service.py
@@ -214,16 +214,16 @@ class Service:
         except RuntimeError:
             pass
 
-    def make_endpoint(self, view, endpoint_type):
+    def make_endpoint(self, view, endpoint_type, organisation=None, project=None):
         return "/".join(
             (
                 self.endpoint,
                 "views",
-                quote_plus(self.organisation),
-                quote_plus(self.project),
+                quote_plus(organisation or self.organisation),
+                quote_plus(project or self.project),
                 quote_plus(view),
                 endpoint_type,
-            )
+            )git
         )
 
     def get_project_context(self) -> Dict:

--- a/kgforge/specializations/stores/nexus/service.py
+++ b/kgforge/specializations/stores/nexus/service.py
@@ -196,7 +196,7 @@ class Service:
         }
 
         self.elastic_endpoint = {
-            "endpoint": self.make_endpoint(elastic_view, "search")
+            "endpoint": self.make_endpoint(elastic_view, "_search")
         }
 
         self.elastic_endpoint["view"] = LazyAction(

--- a/kgforge/specializations/stores/sparql/sparql_service.py
+++ b/kgforge/specializations/stores/sparql/sparql_service.py
@@ -13,14 +13,14 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 
 import copy
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict
 
-from kgforge.core.resource import Resource
 from kgforge.core.commons.context import Context
-from kgforge.core.wrappings.dict import wrap_dict
 
 
 class SPARQLService:
+
+    SPARQL_ENDPOINT_TYPE = "sparql"
 
     def __init__(
         self,
@@ -36,7 +36,7 @@ class SPARQLService:
 
         self.endpoint = endpoint
         self.model_context = model_context
-        self.context_cache: Dict = dict()
+        self.context_cache: Dict = {}
         self.context = store_context
         self.max_connection = max_connection
         self.params = copy.deepcopy(params)
@@ -44,7 +44,8 @@ class SPARQLService:
         self.headers = {"Content-Type": content_type, "Accept": accept}
 
         try:
-            sparql_config = searchendpoints["sparql"]
+            sparql_config = searchendpoints.get("sparql", None)
+
             self.headers_sparql = {
                 "Content-Type": sparql_config["Content-Type"]
                 if sparql_config and "Content-Type" in sparql_config
@@ -54,8 +55,9 @@ class SPARQLService:
                 else "application/sparql-results+json",
             }
 
-            self.sparql_endpoint = dict()
-            self.sparql_endpoint["endpoint"] = searchendpoints["sparql"]["endpoint"]
-            self.sparql_endpoint["type"] = "sparql"
-        except Exception:
-            raise ValueError(f"Store configuration error: sparql searchendpoint missing")
+            self.sparql_endpoint = {
+                "endpoint": searchendpoints["sparql"]["endpoint"]
+            }
+
+        except Exception as e:
+            raise ValueError("Store configuration error: sparql searchendpoint missing") from e

--- a/kgforge/specializations/stores/sparql_store.py
+++ b/kgforge/specializations/stores/sparql_store.py
@@ -101,18 +101,14 @@ class SPARQLStore(DatasetStore):
         distinct = params.get("distinct", False)
         includes = params.get("includes", None)
         excludes = params.get("excludes", None)
-        search_endpoint = params.get(
-            "search_endpoint", self.service.sparql_endpoint["type"]
-        )
-        if search_endpoint not in [
-            self.service.sparql_endpoint["type"],
-        ]:
+        search_endpoint = params.get("search_endpoint", SPARQLService.SPARQL_ENDPOINT_TYPE)
+
+        valid_endpoints = [SPARQLService.SPARQL_ENDPOINT_TYPE]
+
+        if search_endpoint not in valid_endpoints:
             raise ValueError(
-                f"The provided search_endpoint value '{search_endpoint}' is not supported, only 'sparql'"
-            )
-        if "filters" in params:
-            raise ValueError(
-                "A 'filters' key was provided as params filters should be provided as iterable"
+                f"The provided search_endpoint value '{search_endpoint}' is not supported, "
+                f"supported endpoint types are {valid_endpoints}"
             )
 
         if filters:
@@ -130,8 +126,8 @@ class SPARQLStore(DatasetStore):
             )
 
         query_statements, query_filters = SPARQLQueryBuilder.build(
-                schema=None, resolvers=resolvers, context=self.model_context(), filters=filters
-            )
+            schema=None, resolvers=resolvers, context=self.model_context(), filters=filters
+        )
         statements = ";\n ".join(query_statements)
         _filters = (".\n".join(query_filters) + '\n') if len(filters) > 0 else ""
         _vars = ["?id"]
@@ -142,10 +138,10 @@ class SPARQLStore(DatasetStore):
         resources = self.sparql(query, debug=debug, limit=limit, offset=offset)
         return resources
 
-    def _sparql(self, query: str) -> Optional[Union[List[Resource], Resource]]:
+    def _sparql(self, query: str, endpoint: str) -> Optional[Union[List[Resource], Resource]]:
         try:
             response = requests.post(
-                self.service.sparql_endpoint["endpoint"],
+                self.service.sparql_endpoint["endpoint"] if endpoint is None else endpoint,
                 data=query,
                 headers=self.service.headers_sparql
             )

--- a/kgforge/specializations/stores/sparql_store.py
+++ b/kgforge/specializations/stores/sparql_store.py
@@ -74,7 +74,7 @@ class SPARQLStore(DatasetStore):
         raise not_supported()
 
     def _search(
-            self, filters: List[Union[Dict, Filter]],
+            self, *filters: Union[Dict, Filter],
             resolvers: Optional[List[Resolver]] = None, **params
     ) -> List[Resource]:
         # Positional arguments in 'filters' are instances of type Filter from wrappings/paths.py

--- a/tests/specializations/stores/test_bluebrain_nexus.py
+++ b/tests/specializations/stores/test_bluebrain_nexus.py
@@ -17,6 +17,7 @@ from unittest import mock
 from urllib.parse import quote_plus, urljoin
 from urllib.request import pathname2url
 from uuid import uuid4
+from contextlib import nullcontext as does_not_raise
 
 import nexussdk
 import pytest
@@ -595,6 +596,28 @@ class TestQuerying:
 
 
 # Helpers
+
+
+@pytest.mark.parametrize(
+    "view, endpoint_type, expected_endpoint, exception",
+    [
+        (
+                Service.DEFAULT_SPARQL_INDEX_FALLBACK, Service.SPARQL_ENDPOINT_TYPE,
+                "https://nexus-instance.org/views/test/kgforge/https%3A%2F%2Fbluebrain.github.io%2Fnexus%2Fvocabulary%2FdefaultSparqlIndex/sparql", does_not_raise()
+        ),
+        (
+                Service.DEFAULT_ES_INDEX_FALLBACK, Service.ELASTIC_ENDPOINT_TYPE,
+                "https://nexus-instance.org/views/test/kgforge/https%3A%2F%2Fbluebrain.github.io%2Fnexus%2Fvocabulary%2FdefaultElasticSearchIndex/_search", does_not_raise()
+        ),
+        (
+                "any_view_id", "unknown_type", None, pytest.raises(ValueError)
+        )
+    ],
+)
+def test_make_search_endpoint(nexus_store, view, endpoint_type, expected_endpoint, exception):
+    with exception:
+        endpoint = nexus_store.service.make_endpoint(view, endpoint_type=endpoint_type)
+        assert endpoint == expected_endpoint
 
 
 def assert_frozen_id(resource: Resource):

--- a/tests/specializations/stores/test_sparql.py
+++ b/tests/specializations/stores/test_sparql.py
@@ -56,5 +56,5 @@ def test_config(sparql_store, rdf_model):
 
 
 def test_search_params(sparql_store):
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         sparql_store.search(resolvers=[None], filters=[None])


### PR DESCRIPTION
Feature to be able to specify a view when calling forge.sparql, forge.elastic and forge.search, instead of always using the one defined in the config