### PR TITLE
resolving returns also the hasleafregionpart attribute of the resource

### DIFF
--- a/examples/configurations/nexus-resolver/term-to-resource-mapping.hjson
+++ b/examples/configurations/nexus-resolver/term-to-resource-mapping.hjson
@@ -13,6 +13,7 @@
     delineatedBy: x.delineatedBy if hasattr(x, "delineatedBy") else None
     hasLayerLocationPhenotype: x.hasLayerLocationPhenotype if hasattr(x, "hasLayerLocationPhenotype") else None
     representedInAnnotation: x.representedInAnnotation if hasattr(x, "representedInAnnotation") else None
+    hasLeafRegionPart: x.hasLeafRegionPart if hasattr(x, "hasLeafRegionPart") else None
     isPartOf: x.isPartOf if hasattr(x, "isPartOf") else None
     isLayerPartOf: x.isLayerPartOf if hasattr(x, "isLayerPartOf") else None
     units: x.units if hasattr(x, "units") else None

--- a/kgforge/specializations/resolvers/ontology_resolver.py
+++ b/kgforge/specializations/resolvers/ontology_resolver.py
@@ -61,6 +61,7 @@ class OntologyResolver(Resolver):
             delineatedBy ?delineatedBy ;
             hasLayerLocationPhenotype ?hasLayerLocationPhenotype ;
             representedInAnnotation ?representedInAnnotation ;
+            hasLeafRegionPart ?hasLeafRegionPart ;
             isPartOf ?isPartOf ;
             isLayerPartOf ?isLayerPartOf .
         }} WHERE {{
@@ -102,6 +103,9 @@ class OntologyResolver(Resolver):
                 }}
                 OPTIONAL {{
                 ?id representedInAnnotation ?representedInAnnotation .
+                }}
+                OPTIONAL {{
+                ?id hasLeafRegionPart ?hasLeafRegionPart .
                 }}
                 OPTIONAL {{
                 ?id isPartOf ?isPartOf .


### PR DESCRIPTION
forge.resolve now returns resource.hasLeafRegionPart if available. This helps when resolving brain regions to check if a layer should be provided or not.