### PR TITLE
Improved deflatten function

### DIFF
--- a/kgforge/core/conversions/dataframe.py
+++ b/kgforge/core/conversions/dataframe.py
@@ -63,6 +63,7 @@ def _from_dataframe(row: Series, na: Union[Any, List[Any]], nesting: str) -> Res
     data = deflatten(items, nesting)
     return from_json(data, None)
 
+
 def deflatten(items: List[Tuple[str, Any]], sep: str) -> Dict:
     d = {}
     split = []
@@ -74,21 +75,16 @@ def deflatten(items: List[Tuple[str, Any]], sep: str) -> Dict:
             pre, _ = k1.split(sep, maxsplit=1)
             if pre in d:
                 raise ValueError(f'Mix of {pre} and {pre}{sep} (e.g. {k1}). Cannot be processed!')
-            l = []
+            pitems = []
             for n2, t2_ in enumerate(items):
-                try:
-                    k2, v2 = t2_
-                except:
-                    print(n2,t2_)
-                    return 0
+                k2, v2 = t2_
                 if isinstance(k2, str) and k2.startswith(f'{pre}{sep}'):
                     _, post = k2.split(sep, maxsplit=1)
-                    l.append((post, v2))
+                    pitems.append((post, v2))
                     split.append(n2)
-            d[pre] = deflatten(l, sep)
+            d[pre] = deflatten(pitems, sep)
         else:
             if k1 in d:
-                print('b',d)
                 raise ValueError(f'Mix of {pre} and {pre}{sep} (e.g. {k1}). Cannot be processed!')
             d[k1] = v1
     return d


### PR DESCRIPTION
As of now, deflatten assumed that all items are ordered according to the nesting. Different input would lead to several values being discarded. For instance `[('p1.id', 'id1'), ('p1.type', 'type1'), ('p2.id', 'id2'), ('p2.type', 'type2'), ('p1.x', 'x1'), ('p2.x', 'x2')]` would cause such issue.
Furthermore, if a key appears both as nested and not nested (e.g. 'p1', and 'p1.x') the non-nested value would be discarded without providing any warning.

The current version ensures that:
- the output of flatten is independent of the order and no value is discarded
- a ValueError with an insightful message is raised if  a key appears both as nested and not nested

Two tests have been added to check this. 
Closes #378