### PR TITLE
Batch retrieve

### DIFF
--- a/examples/notebooks/use-cases/BBP KG Forge retrieval.ipynb
+++ b/examples/notebooks/use-cases/BBP KG Forge retrieval.ipynb
@@ -2,17 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 28,
    "id": "2c4aec45-da10-4b11-8469-b0e62f8a0c31",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from kgforge.core import KnowledgeGraphForge"
+    "from kgforge.core import KnowledgeGraphForge, Resource"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 29,
    "id": "0ac8879d-b05b-482c-94b6-e46437291854",
    "metadata": {},
    "outputs": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 30,
    "id": "eb70f64b-7ca2-4c71-a725-87cfd7ce2e1d",
    "metadata": {},
    "outputs": [],
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 31,
    "id": "826d1183-6898-4977-b7ee-9518e4095fef",
    "metadata": {},
    "outputs": [
@@ -199,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 32,
    "id": "039cb6c5-12c3-45ec-9dad-100d64969e85",
    "metadata": {},
    "outputs": [],
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 33,
    "id": "c28cdc68-895d-4aea-b56b-c1dff7d0168a",
    "metadata": {},
    "outputs": [],
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 34,
    "id": "078e8978-b949-49e3-a4ae-6fe4ef0b15a1",
    "metadata": {},
    "outputs": [
@@ -229,16 +229,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "         1051911 function calls (991812 primitive calls) in 0.533 seconds\n",
+      "         5351677 function calls (5054656 primitive calls) in 1.886 seconds\n",
       "\n",
       "   Random listing order was used\n",
-      "   List reduced from 644 to 1 due to restriction <1>\n",
+      "   List reduced from 684 to 1 due to restriction <1>\n",
       "\n",
       "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-      "       66    0.000    0.000    0.000    0.000 /usr/local/Cellar/python@3.8/3.8.17_1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/abc.py:96(__instancecheck__)\n",
+      "        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1017(_handle_fromlist)\n",
       "\n",
       "\n",
-      "['https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/75549784-55d3-4cec-8968-a00f2a07a2fd', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a8722f9e-a8a4-499a-b64c-3856ebfd01a6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d0d38bab-5e01-4d8f-a98a-ccaca6f73b43', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/085d634e-50fd-4fde-9372-6535b9090178', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_6', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_7', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_9', 'https://bbp.epfl.ch/data/dke/kgforge/237312a3-ebaf-4f1c-8443-b2be237d42d1', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/5c835502-ed29-46ff-a07c-0913dbba6c70', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/69c7f853-4407-4e6f-a9b2-840c8c1c3ea7', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/17759807-5dbe-44c5-8f6e-ac6ef1ce1299']\n"
+      "['https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/75549784-55d3-4cec-8968-a00f2a07a2fd', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a8722f9e-a8a4-499a-b64c-3856ebfd01a6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d0d38bab-5e01-4d8f-a98a-ccaca6f73b43', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/085d634e-50fd-4fde-9372-6535b9090178', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_6', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_7', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_9', 'https://bbp.epfl.ch/data/dke/kgforge/237312a3-ebaf-4f1c-8443-b2be237d42d1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_18_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_87_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_46_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_67_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_75_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_65_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_56_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_60_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_70_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_15_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_92_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_64_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_84_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_33_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_90_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_78_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_38_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_81_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_97_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_42_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_39_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_29_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_62_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_9_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_63_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_72_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_89_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_76_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_91_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_1_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_21_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_6_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_4_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_51_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_82_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_79_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_44_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_83_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_19_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_85_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_12_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_27_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_32_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_98_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_7_3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/5c835502-ed29-46ff-a07c-0913dbba6c70', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/69c7f853-4407-4e6f-a9b2-840c8c1c3ea7', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/17759807-5dbe-44c5-8f6e-ac6ef1ce1299', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/8701d132-2ded-480d-b366-07a007c99684', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/0acfd1e6-ebc6-4fe6-841d-fc8c02ac73c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/49ed1888-7a87-40bb-b1f3-cde4bf5f3fc4', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/9209b6b8-2b01-4fbd-a753-02eb1307ef9e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fd3f1395-d270-4079-81b0-d293407fcce0', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/914aa432-2fcc-4098-a8ec-5dada60149c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fe20e514-b234-419b-9443-8a103208e00e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/35296363-23cd-4157-8b64-122c83415d95', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/002d787f-f36e-43a7-b9a9-8bf5e94202c2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/27832cd6-1b49-4db0-a6cc-058bbd2a04f2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/627eda77-fb81-41ed-80b6-10d6257f1d89', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/4c1c40b7-89a2-4044-9614-e07a4bc9168d', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/94176355-b290-41a0-a2e6-e298bf3d0176', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/4a98e1d1-9bb6-4deb-98ec-0133dc342995', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b429dee5-1c35-4c2c-b475-bd5a4639e1f4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/d13c4b2d-3543-4e40-9479-21006f66e380', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/bfc627c4-5326-4f6b-8aed-27ecb87eb0e8', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/543faf75-fc3d-4a1a-9861-11788dae5657', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/376ecc74-68e1-4324-8498-500a2a086872', 'https://bbp.epfl.ch/data/dke/kgforge/8f664b12-ea33-4d2e-90a7-ca2ac3fea22f', 'https://bbp.epfl.ch/data/dke/kgforge/a5fadaa1-d06e-4f36-a5f1-72e8d1044257', 'https://bbp.epfl.ch/data/dke/kgforge/3ef8f85e-b22a-46a3-b485-79881799113b', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b9cb9987-ea99-4bce-b6d8-54930214d418', 'https://bbp.epfl.ch/data/dke/kgforge/c8cf0388-1ab7-4e3a-8b58-6841caab4148', 'https://bbp.epfl.ch/data/dke/kgforge/b280ca27-ca81-4d70-8d10-cb8cdf143682', 'https://bbp.epfl.ch/data/dke/kgforge/af15bef9-3894-42e1-8a46-4f38640c40b9', 'https://bbp.epfl.ch/data/dke/kgforge/ea93f167-32b8-44e9-b3c3-a48869512da7', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d69c348d-f471-4b04-b49b-54cd86e8143e', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/328e177e-60a5-4443-ad41-9164fa4c0e44', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/8a6bdd54-7fa0-4280-a8de-de5d067cc973', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/ea756a5a-5c64-4454-b3db-5218d370356d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/710ea3db-871c-4bc1-89eb-88b1e63b9320', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/be207a5d-2558-4ccc-9b2b-68bde3c72729', None, 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff']\n",
+      "Errors\n",
+      "[None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, Action(error='RetrievalError', message=\"404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/:%2F%2FNCBITaxon:10090')\", operation='_retrieve_many', succeeded=False), None]\n"
      ]
     }
    ],
@@ -246,12 +248,15 @@
     "with cProfile.Profile() as pr:\n",
     "    test_1 = forge.retrieve([e.id for e in entities])\n",
     "    pstats.Stats(pr).print_stats(1)\n",
-    "    print([r.get_identifier() for r in test_1])"
+    "    print([r.get_identifier() if isinstance(r, Resource) else None for r in test_1])\n",
+    "    print(\"Errors\")\n",
+    "    print([r if not isinstance(r, Resource) else None for r in test_1])\n",
+    "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 35,
    "id": "69823c02-96cf-4e1a-aecf-7ab6989bc3f4",
    "metadata": {},
    "outputs": [
@@ -262,34 +267,16 @@
       "<action> catch_http_error\n",
       "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:10090')\n",
       "\n",
-      "<action> catch_http_error\n",
-      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:11090')\n",
-      "\n",
-      "<action> catch_http_error\n",
-      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:17090')\n",
-      "\n",
-      "<action> catch_http_error\n",
-      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19090')\n",
-      "\n",
-      "<action> catch_http_error\n",
-      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19390')\n",
-      "\n",
-      "<action> catch_http_error\n",
-      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19890')\n",
-      "\n",
-      "<action> catch_http_error\n",
-      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19891')\n",
-      "\n",
-      "         5127879 function calls (4852814 primitive calls) in 8.782 seconds\n",
+      "         5364936 function calls (5083259 primitive calls) in 8.307 seconds\n",
       "\n",
       "   Random listing order was used\n",
-      "   List reduced from 682 to 1 due to restriction <1>\n",
+      "   List reduced from 694 to 1 due to restriction <1>\n",
       "\n",
       "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
-      "      293    0.000    0.000    0.001    0.000 /usr/local/Cellar/python@3.8/3.8.17_1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/abc.py:96(__instancecheck__)\n",
+      "        2    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:1017(_handle_fromlist)\n",
       "\n",
       "\n",
-      "['https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/75549784-55d3-4cec-8968-a00f2a07a2fd', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a8722f9e-a8a4-499a-b64c-3856ebfd01a6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d0d38bab-5e01-4d8f-a98a-ccaca6f73b43', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/085d634e-50fd-4fde-9372-6535b9090178', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_6', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_7', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_9', 'https://bbp.epfl.ch/data/dke/kgforge/237312a3-ebaf-4f1c-8443-b2be237d42d1', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/5c835502-ed29-46ff-a07c-0913dbba6c70', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/69c7f853-4407-4e6f-a9b2-840c8c1c3ea7', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/17759807-5dbe-44c5-8f6e-ac6ef1ce1299', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/8701d132-2ded-480d-b366-07a007c99684', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/0acfd1e6-ebc6-4fe6-841d-fc8c02ac73c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/49ed1888-7a87-40bb-b1f3-cde4bf5f3fc4', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/9209b6b8-2b01-4fbd-a753-02eb1307ef9e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fd3f1395-d270-4079-81b0-d293407fcce0', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/914aa432-2fcc-4098-a8ec-5dada60149c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fe20e514-b234-419b-9443-8a103208e00e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/35296363-23cd-4157-8b64-122c83415d95', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/002d787f-f36e-43a7-b9a9-8bf5e94202c2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/27832cd6-1b49-4db0-a6cc-058bbd2a04f2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/627eda77-fb81-41ed-80b6-10d6257f1d89', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/4c1c40b7-89a2-4044-9614-e07a4bc9168d', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/94176355-b290-41a0-a2e6-e298bf3d0176', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/4a98e1d1-9bb6-4deb-98ec-0133dc342995', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b429dee5-1c35-4c2c-b475-bd5a4639e1f4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/d13c4b2d-3543-4e40-9479-21006f66e380', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/bfc627c4-5326-4f6b-8aed-27ecb87eb0e8', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/543faf75-fc3d-4a1a-9861-11788dae5657', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/376ecc74-68e1-4324-8498-500a2a086872', 'https://bbp.epfl.ch/data/dke/kgforge/8f664b12-ea33-4d2e-90a7-ca2ac3fea22f', 'https://bbp.epfl.ch/data/dke/kgforge/a5fadaa1-d06e-4f36-a5f1-72e8d1044257', 'https://bbp.epfl.ch/data/dke/kgforge/3ef8f85e-b22a-46a3-b485-79881799113b', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b9cb9987-ea99-4bce-b6d8-54930214d418', 'https://bbp.epfl.ch/data/dke/kgforge/c8cf0388-1ab7-4e3a-8b58-6841caab4148', 'https://bbp.epfl.ch/data/dke/kgforge/b280ca27-ca81-4d70-8d10-cb8cdf143682', 'https://bbp.epfl.ch/data/dke/kgforge/af15bef9-3894-42e1-8a46-4f38640c40b9', 'https://bbp.epfl.ch/data/dke/kgforge/ea93f167-32b8-44e9-b3c3-a48869512da7', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d69c348d-f471-4b04-b49b-54cd86e8143e', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/328e177e-60a5-4443-ad41-9164fa4c0e44', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/8a6bdd54-7fa0-4280-a8de-de5d067cc973', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/ea756a5a-5c64-4454-b3db-5218d370356d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/710ea3db-871c-4bc1-89eb-88b1e63b9320', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/be207a5d-2558-4ccc-9b2b-68bde3c72729', None, 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/8790d012-6588-4de7-9569-d150d6603d8d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/27533f16-4af3-4c0e-9817-4963fc5134b8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/658ea892-0898-4f97-a2ff-4d2fb68e33e5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/88890bbe-99bc-4291-9aef-512a52962d02', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/4eb94adf-02a3-4524-92a6-78356c10a965', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/2851e92d-04c5-4928-a71b-dda15f26f90d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/110578f0-81bc-4b8b-9ce4-899ed51dbca4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/6a451198-aa48-4ec6-8f21-83b79b8fe004', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/41a62200-2eeb-4933-aaf6-863be7fea94c', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/c1825350-07be-476b-88f3-58d1f55effc0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/353c57f5-d92a-4957-9789-7c880c9e7b66', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/42f46a77-f146-472c-9ab5-97fa1bdfbf81', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/df79c401-27fa-48f0-9440-c66b37232aaa', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/46a54f29-0a5f-4b27-9ee0-bd021792f8e4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/9b646521-b9e7-4c65-a382-fc7955fc5b2f', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/7774dcda-32a6-45f5-b39a-d19235fa9b0f', 'https://bbp.epfl.ch/neurosciencegraph/data/e45a145f-ff29-4132-80f0-5834b814d4a1', 'https://bbp.epfl.ch/neurosciencegraph/data/c984417f-d533-4782-9747-7ececf56db3b', 'https://bbp.epfl.ch/neurosciencegraph/data/42dc2ce2-a9ff-493b-8250-57138ebf032d', 'https://bbp.epfl.ch/neurosciencegraph/data/462a27e7-9fa9-4834-9453-a49a4c54404e', 'https://bbp.epfl.ch/neurosciencegraph/data/74a1b53e-465c-4340-ba09-b1e162fe3177', 'https://bbp.epfl.ch/neurosciencegraph/data/6d038669-086a-4826-8858-61eb67ca341c', 'https://bbp.epfl.ch/neurosciencegraph/data/ff23565e-4195-4e3e-a1ff-ac20e419b9c6', 'https://bbp.epfl.ch/neurosciencegraph/data/493f229e-c84a-4d51-9d64-effb95cd8059', 'https://bbp.epfl.ch/neurosciencegraph/data/36f00d62-9447-463f-8d80-755041017918', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/428b1d7e-2ee2-4ffa-b147-e811a9076967', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/3b71a8f8-ee0d-4dd6-9463-8f2bbdb7978b', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/8a5c8dd3-93a0-4161-a33f-5068a75d0877', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/d570677b-0bb5-4668-a62f-4eb8a6db4ba2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/e71b85c8-7ece-4e37-a843-405b684417d2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/3336e8e4-e908-46c2-95cf-f3d3a051b76c', 'https://example.org', 'https://example2.org', 'https://example3.org', 'https://example4.org', 'https://example5.org', 'https://example6.org', 'https://example7.org', 'https://example8.org', None, None, None, None, None, None]\n"
+      "['https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/75549784-55d3-4cec-8968-a00f2a07a2fd', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a8722f9e-a8a4-499a-b64c-3856ebfd01a6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d0d38bab-5e01-4d8f-a98a-ccaca6f73b43', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/085d634e-50fd-4fde-9372-6535b9090178', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_6', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_7', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_9', 'https://bbp.epfl.ch/data/dke/kgforge/237312a3-ebaf-4f1c-8443-b2be237d42d1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_18_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_87_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_46_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_67_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_75_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_65_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_56_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_60_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_70_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_15_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_92_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_64_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_84_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_33_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_90_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_78_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_38_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_81_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_97_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_42_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_39_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_29_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_62_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_9_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_63_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_72_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_89_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_76_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_91_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_1_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_21_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_6_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_4_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_51_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_82_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_79_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_44_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_83_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_19_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_85_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_12_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_27_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_32_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_98_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/test_resource_7_3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/5c835502-ed29-46ff-a07c-0913dbba6c70', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/69c7f853-4407-4e6f-a9b2-840c8c1c3ea7', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/17759807-5dbe-44c5-8f6e-ac6ef1ce1299', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/8701d132-2ded-480d-b366-07a007c99684', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/0acfd1e6-ebc6-4fe6-841d-fc8c02ac73c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/49ed1888-7a87-40bb-b1f3-cde4bf5f3fc4', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/9209b6b8-2b01-4fbd-a753-02eb1307ef9e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fd3f1395-d270-4079-81b0-d293407fcce0', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/914aa432-2fcc-4098-a8ec-5dada60149c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fe20e514-b234-419b-9443-8a103208e00e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/35296363-23cd-4157-8b64-122c83415d95', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/002d787f-f36e-43a7-b9a9-8bf5e94202c2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/27832cd6-1b49-4db0-a6cc-058bbd2a04f2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/627eda77-fb81-41ed-80b6-10d6257f1d89', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/4c1c40b7-89a2-4044-9614-e07a4bc9168d', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/94176355-b290-41a0-a2e6-e298bf3d0176', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/4a98e1d1-9bb6-4deb-98ec-0133dc342995', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b429dee5-1c35-4c2c-b475-bd5a4639e1f4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/d13c4b2d-3543-4e40-9479-21006f66e380', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/bfc627c4-5326-4f6b-8aed-27ecb87eb0e8', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/543faf75-fc3d-4a1a-9861-11788dae5657', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/376ecc74-68e1-4324-8498-500a2a086872', 'https://bbp.epfl.ch/data/dke/kgforge/8f664b12-ea33-4d2e-90a7-ca2ac3fea22f', 'https://bbp.epfl.ch/data/dke/kgforge/a5fadaa1-d06e-4f36-a5f1-72e8d1044257', 'https://bbp.epfl.ch/data/dke/kgforge/3ef8f85e-b22a-46a3-b485-79881799113b', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b9cb9987-ea99-4bce-b6d8-54930214d418', 'https://bbp.epfl.ch/data/dke/kgforge/c8cf0388-1ab7-4e3a-8b58-6841caab4148', 'https://bbp.epfl.ch/data/dke/kgforge/b280ca27-ca81-4d70-8d10-cb8cdf143682', 'https://bbp.epfl.ch/data/dke/kgforge/af15bef9-3894-42e1-8a46-4f38640c40b9', 'https://bbp.epfl.ch/data/dke/kgforge/ea93f167-32b8-44e9-b3c3-a48869512da7', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d69c348d-f471-4b04-b49b-54cd86e8143e', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/328e177e-60a5-4443-ad41-9164fa4c0e44', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/8a6bdd54-7fa0-4280-a8de-de5d067cc973', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/ea756a5a-5c64-4454-b3db-5218d370356d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/710ea3db-871c-4bc1-89eb-88b1e63b9320', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/be207a5d-2558-4ccc-9b2b-68bde3c72729', None, 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff']\n"
      ]
     }
    ],
@@ -302,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 36,
    "id": "8d9fd6b5-eaee-4251-ba01-2d67434988ea",
    "metadata": {},
    "outputs": [],
@@ -324,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 37,
    "id": "7546fc67-0ebb-4a9f-b6ee-ca3818736880",
    "metadata": {},
    "outputs": [],
@@ -334,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 38,
    "id": "ad26dbff-1e82-4105-9344-301b73c4db7f",
    "metadata": {},
    "outputs": [],
@@ -344,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 39,
    "id": "6746f7fa-8f45-416e-b153-58ba4b846c88",
    "metadata": {},
    "outputs": [
@@ -354,13 +341,16 @@
      "text": [
       "Succeeded:  True - Identifier: https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6\n",
       "Succeeded:  True - Identifier: https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4\n",
-      "Succeeded:  False - Identifier: None\n"
+      "Succeeded:  False\n"
      ]
     }
    ],
    "source": [
     "for r in test_3:\n",
-    "    print(\"Succeeded: \", r._last_action.succeeded, \"- Identifier:\", r.get_identifier())"
+    "    if isinstance(r, Resource):\n",
+    "        print(\"Succeeded: \", r._last_action.succeeded, \"- Identifier:\", r.get_identifier())\n",
+    "    else:\n",
+    "        print(\"Succeeded: \", r.succeeded)"
    ]
   }
  ],

--- a/examples/notebooks/use-cases/BBP KG Forge retrieval.ipynb
+++ b/examples/notebooks/use-cases/BBP KG Forge retrieval.ipynb
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "826d1183-6898-4977-b7ee-9518e4095fef",
    "metadata": {},
    "outputs": [
@@ -78,61 +78,77 @@
      "output_type": "stream",
      "text": [
       "Execution 0  using:  id inside:  same bucket  - Cross bucket: True  - Retrieve source: True\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 1  using:  self inside:  same bucket  - Cross bucket: True  - Retrieve source: True\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/https:%2F%2Fbbp.epfl.ch%2Fnexus%2Fv1%2Fresources%2Fdke%2Fkgforge%2F_%2F20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 2  using:  id inside:  other bucket  - Cross bucket: True  - Retrieve source: True\n",
+      "http://purl.obolibrary.org/obo/GO_0038048\n",
       "rev 3 https://bbp.neuroshapes.org http://purl.obolibrary.org/obo/GO_0038048\n",
       "______________________\n",
       "Execution 3  using:  self inside:  other bucket  - Cross bucket: True  - Retrieve source: True\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048\n",
       "rev 3 https://bbp.neuroshapes.org http://purl.obolibrary.org/obo/GO_0038048\n",
       "______________________\n",
       "Execution 4  using:  id inside:  same bucket  - Cross bucket: False  - Retrieve source: True\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 5  using:  self inside:  same bucket  - Cross bucket: False  - Retrieve source: True\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/https:%2F%2Fbbp.epfl.ch%2Fnexus%2Fv1%2Fresources%2Fdke%2Fkgforge%2F_%2F20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 6  using:  id inside:  other bucket  - Cross bucket: False  - Retrieve source: True\n",
+      "http://purl.obolibrary.org/obo/GO_0038048\n",
       "<action> catch_http_error\n",
-      "<error> RetrievalError: 404 Client Error: Not Found for url: https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048')\n",
       "\n",
       "Not found\n",
       "______________________\n",
       "Execution 7  using:  self inside:  other bucket  - Cross bucket: False  - Retrieve source: True\n",
-      "<action> retrieve\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048\n",
+      "<action> _retrieve\n",
       "<error> RetrievalError: Provided resource identifier https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048 is not inside the current bucket, use cross_bucket=True to be able to retrieve it\n",
       "\n",
       "Not found\n",
       "______________________\n",
       "Execution 8  using:  id inside:  same bucket  - Cross bucket: True  - Retrieve source: False\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 9  using:  self inside:  same bucket  - Cross bucket: True  - Retrieve source: False\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/https:%2F%2Fbbp.epfl.ch%2Fnexus%2Fv1%2Fresources%2Fdke%2Fkgforge%2F_%2F20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 10  using:  id inside:  other bucket  - Cross bucket: True  - Retrieve source: False\n",
+      "http://purl.obolibrary.org/obo/GO_0038048\n",
       "rev 3 https://bbp.neuroshapes.org GO:0038048\n",
       "______________________\n",
       "Execution 11  using:  self inside:  other bucket  - Cross bucket: True  - Retrieve source: False\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048\n",
       "rev 3 https://bbp.neuroshapes.org GO:0038048\n",
       "______________________\n",
       "Execution 12  using:  id inside:  same bucket  - Cross bucket: False  - Retrieve source: False\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 13  using:  self inside:  same bucket  - Cross bucket: False  - Retrieve source: False\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/https:%2F%2Fbbp.epfl.ch%2Fnexus%2Fv1%2Fresources%2Fdke%2Fkgforge%2F_%2F20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "rev 3 https://bbp.neuroshapes.org https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff\n",
       "______________________\n",
       "Execution 14  using:  id inside:  other bucket  - Cross bucket: False  - Retrieve source: False\n",
+      "http://purl.obolibrary.org/obo/GO_0038048\n",
       "<action> catch_http_error\n",
-      "<error> RetrievalError: 404 Client Error: Not Found for url: https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048')\n",
       "\n",
       "Not found\n",
       "______________________\n",
       "Execution 15  using:  self inside:  other bucket  - Cross bucket: False  - Retrieve source: False\n",
-      "<action> retrieve\n",
+      "https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048\n",
+      "<action> _retrieve\n",
       "<error> RetrievalError: Provided resource identifier https://bbp.epfl.ch/nexus/v1/resources/neurosciencegraph/datamodels/_/http:%2F%2Fpurl.obolibrary.org%2Fobo%2FGO_0038048 is not inside the current bucket, use cross_bucket=True to be able to retrieve it\n",
       "\n",
       "Not found\n",
@@ -162,6 +178,7 @@
     "\n",
     "            print(f\"Execution {i}\", \" using: \", type_, \"inside: \", loc, \" - Cross bucket:\", cb, \" - Retrieve source:\", rs)\n",
     "\n",
+    "            print(el)\n",
     "            e = forge.retrieve(el, cross_bucket=cb, retrieve_source=rs)\n",
     "\n",
     "            if not e:\n",
@@ -170,6 +187,180 @@
     "                print(\"rev\", e._store_metadata._rev, e.context, e.id)\n",
     "            print(\"______________________\")\n",
     "            i += 1\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1d89492-79a3-44c2-8304-4f40516c2832",
+   "metadata": {},
+   "source": [
+    "# Batch Retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "039cb6c5-12c3-45ec-9dad-100d64969e85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pstats\n",
+    "import cProfile\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c28cdc68-895d-4aea-b56b-c1dff7d0168a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entities = forge.search({\"type\": \"Entity\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "078e8978-b949-49e3-a4ae-6fe4ef0b15a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "         1051911 function calls (991812 primitive calls) in 0.533 seconds\n",
+      "\n",
+      "   Random listing order was used\n",
+      "   List reduced from 644 to 1 due to restriction <1>\n",
+      "\n",
+      "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
+      "       66    0.000    0.000    0.000    0.000 /usr/local/Cellar/python@3.8/3.8.17_1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/abc.py:96(__instancecheck__)\n",
+      "\n",
+      "\n",
+      "['https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/75549784-55d3-4cec-8968-a00f2a07a2fd', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a8722f9e-a8a4-499a-b64c-3856ebfd01a6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d0d38bab-5e01-4d8f-a98a-ccaca6f73b43', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/085d634e-50fd-4fde-9372-6535b9090178', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_6', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_7', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_9', 'https://bbp.epfl.ch/data/dke/kgforge/237312a3-ebaf-4f1c-8443-b2be237d42d1', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/5c835502-ed29-46ff-a07c-0913dbba6c70', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/69c7f853-4407-4e6f-a9b2-840c8c1c3ea7', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/17759807-5dbe-44c5-8f6e-ac6ef1ce1299']\n"
+     ]
+    }
+   ],
+   "source": [
+    "with cProfile.Profile() as pr:\n",
+    "    test_1 = forge.retrieve([e.id for e in entities])\n",
+    "    pstats.Stats(pr).print_stats(1)\n",
+    "    print([r.get_identifier() for r in test_1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "69823c02-96cf-4e1a-aecf-7ab6989bc3f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:10090')\n",
+      "\n",
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:11090')\n",
+      "\n",
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:17090')\n",
+      "\n",
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19090')\n",
+      "\n",
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19390')\n",
+      "\n",
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19890')\n",
+      "\n",
+      "<action> catch_http_error\n",
+      "<error> RetrievalError: 404, message='Not Found', url=URL('https://bbp.epfl.ch/nexus/v1/resolvers/dke/kgforge/_/:%2F%2FNCBITaxon:19891')\n",
+      "\n",
+      "         5127879 function calls (4852814 primitive calls) in 8.782 seconds\n",
+      "\n",
+      "   Random listing order was used\n",
+      "   List reduced from 682 to 1 due to restriction <1>\n",
+      "\n",
+      "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)\n",
+      "      293    0.000    0.000    0.001    0.000 /usr/local/Cellar/python@3.8/3.8.17_1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/abc.py:96(__instancecheck__)\n",
+      "\n",
+      "\n",
+      "['https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/75549784-55d3-4cec-8968-a00f2a07a2fd', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/a8722f9e-a8a4-499a-b64c-3856ebfd01a6', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d0d38bab-5e01-4d8f-a98a-ccaca6f73b43', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/085d634e-50fd-4fde-9372-6535b9090178', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_1', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_3', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_6', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_7', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/dummy_resource_9', 'https://bbp.epfl.ch/data/dke/kgforge/237312a3-ebaf-4f1c-8443-b2be237d42d1', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/5c835502-ed29-46ff-a07c-0913dbba6c70', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/69c7f853-4407-4e6f-a9b2-840c8c1c3ea7', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/17759807-5dbe-44c5-8f6e-ac6ef1ce1299', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/8701d132-2ded-480d-b366-07a007c99684', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/0acfd1e6-ebc6-4fe6-841d-fc8c02ac73c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/49ed1888-7a87-40bb-b1f3-cde4bf5f3fc4', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/9209b6b8-2b01-4fbd-a753-02eb1307ef9e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fd3f1395-d270-4079-81b0-d293407fcce0', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/914aa432-2fcc-4098-a8ec-5dada60149c3', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/fe20e514-b234-419b-9443-8a103208e00e', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/35296363-23cd-4157-8b64-122c83415d95', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/002d787f-f36e-43a7-b9a9-8bf5e94202c2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/27832cd6-1b49-4db0-a6cc-058bbd2a04f2', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/627eda77-fb81-41ed-80b6-10d6257f1d89', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/4c1c40b7-89a2-4044-9614-e07a4bc9168d', 'https://bbp.epfl.ch/neurosciencegraph/data/factsheets/94176355-b290-41a0-a2e6-e298bf3d0176', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/4a98e1d1-9bb6-4deb-98ec-0133dc342995', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b429dee5-1c35-4c2c-b475-bd5a4639e1f4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/d13c4b2d-3543-4e40-9479-21006f66e380', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/bfc627c4-5326-4f6b-8aed-27ecb87eb0e8', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/543faf75-fc3d-4a1a-9861-11788dae5657', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/376ecc74-68e1-4324-8498-500a2a086872', 'https://bbp.epfl.ch/data/dke/kgforge/8f664b12-ea33-4d2e-90a7-ca2ac3fea22f', 'https://bbp.epfl.ch/data/dke/kgforge/a5fadaa1-d06e-4f36-a5f1-72e8d1044257', 'https://bbp.epfl.ch/data/dke/kgforge/3ef8f85e-b22a-46a3-b485-79881799113b', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/b9cb9987-ea99-4bce-b6d8-54930214d418', 'https://bbp.epfl.ch/data/dke/kgforge/c8cf0388-1ab7-4e3a-8b58-6841caab4148', 'https://bbp.epfl.ch/data/dke/kgforge/b280ca27-ca81-4d70-8d10-cb8cdf143682', 'https://bbp.epfl.ch/data/dke/kgforge/af15bef9-3894-42e1-8a46-4f38640c40b9', 'https://bbp.epfl.ch/data/dke/kgforge/ea93f167-32b8-44e9-b3c3-a48869512da7', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/d69c348d-f471-4b04-b49b-54cd86e8143e', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/328e177e-60a5-4443-ad41-9164fa4c0e44', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/8a6bdd54-7fa0-4280-a8de-de5d067cc973', 'https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/ea756a5a-5c64-4454-b3db-5218d370356d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/710ea3db-871c-4bc1-89eb-88b1e63b9320', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/be207a5d-2558-4ccc-9b2b-68bde3c72729', None, 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/20fbc97a-fb26-43ff-8093-9136aab25dff', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/8790d012-6588-4de7-9569-d150d6603d8d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/27533f16-4af3-4c0e-9817-4963fc5134b8', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/658ea892-0898-4f97-a2ff-4d2fb68e33e5', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/88890bbe-99bc-4291-9aef-512a52962d02', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/4eb94adf-02a3-4524-92a6-78356c10a965', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/2851e92d-04c5-4928-a71b-dda15f26f90d', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/110578f0-81bc-4b8b-9ce4-899ed51dbca4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/6a451198-aa48-4ec6-8f21-83b79b8fe004', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/41a62200-2eeb-4933-aaf6-863be7fea94c', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/c1825350-07be-476b-88f3-58d1f55effc0', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/353c57f5-d92a-4957-9789-7c880c9e7b66', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/42f46a77-f146-472c-9ab5-97fa1bdfbf81', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/df79c401-27fa-48f0-9440-c66b37232aaa', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/46a54f29-0a5f-4b27-9ee0-bd021792f8e4', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/9b646521-b9e7-4c65-a382-fc7955fc5b2f', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/7774dcda-32a6-45f5-b39a-d19235fa9b0f', 'https://bbp.epfl.ch/neurosciencegraph/data/e45a145f-ff29-4132-80f0-5834b814d4a1', 'https://bbp.epfl.ch/neurosciencegraph/data/c984417f-d533-4782-9747-7ececf56db3b', 'https://bbp.epfl.ch/neurosciencegraph/data/42dc2ce2-a9ff-493b-8250-57138ebf032d', 'https://bbp.epfl.ch/neurosciencegraph/data/462a27e7-9fa9-4834-9453-a49a4c54404e', 'https://bbp.epfl.ch/neurosciencegraph/data/74a1b53e-465c-4340-ba09-b1e162fe3177', 'https://bbp.epfl.ch/neurosciencegraph/data/6d038669-086a-4826-8858-61eb67ca341c', 'https://bbp.epfl.ch/neurosciencegraph/data/ff23565e-4195-4e3e-a1ff-ac20e419b9c6', 'https://bbp.epfl.ch/neurosciencegraph/data/493f229e-c84a-4d51-9d64-effb95cd8059', 'https://bbp.epfl.ch/neurosciencegraph/data/36f00d62-9447-463f-8d80-755041017918', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/428b1d7e-2ee2-4ffa-b147-e811a9076967', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/3b71a8f8-ee0d-4dd6-9463-8f2bbdb7978b', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/8a5c8dd3-93a0-4161-a33f-5068a75d0877', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/d570677b-0bb5-4668-a62f-4eb8a6db4ba2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/e71b85c8-7ece-4e37-a843-405b684417d2', 'https://bbp.epfl.ch/nexus/v1/resources/dke/kgforge/_/3336e8e4-e908-46c2-95cf-f3d3a051b76c', 'https://example.org', 'https://example2.org', 'https://example3.org', 'https://example4.org', 'https://example5.org', 'https://example6.org', 'https://example7.org', 'https://example8.org', None, None, None, None, None, None]\n"
+     ]
+    }
+   ],
+   "source": [
+    "with cProfile.Profile() as pr:\n",
+    "    test_2 = [forge.retrieve(e.id, cross_bucket=True) for e in entities]\n",
+    "    pstats.Stats(pr).print_stats(1)\n",
+    "    print([r.get_identifier() if r else None for r in test_2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8d9fd6b5-eaee-4251-ba01-2d67434988ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert all(\n",
+    "    json.dumps(forge.as_json(e)) == json.dumps(forge.as_json(e2)) \n",
+    "    for e, e2 in zip(test_1, test_2)\n",
+    "    if e is not None and e2 is not None\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca49f603-5740-4954-b8c2-6df1c4be4325",
+   "metadata": {},
+   "source": [
+    "## Error handling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "7546fc67-0ebb-4a9f-b6ee-ca3818736880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ids = [e.id for e in entities[:2]] + [\"unknown_id\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "ad26dbff-1e82-4105-9344-301b73c4db7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_3 = forge.retrieve(ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "6746f7fa-8f45-416e-b153-58ba4b846c88",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Succeeded:  True - Identifier: https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/545eaa9a-be49-470f-b5bc-907fbee0cde6\n",
+      "Succeeded:  True - Identifier: https://bbp.epfl.ch/neurosciencegraph/data/neuronmorphologies/9842b6d6-4536-4f27-b2eb-ac2f9363f3f4\n",
+      "Succeeded:  False - Identifier: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "for r in test_3:\n",
+    "    print(\"Succeeded: \", r._last_action.succeeded, \"- Identifier:\", r.get_identifier())"
    ]
   }
  ],

--- a/kgforge/core/commons/execution.py
+++ b/kgforge/core/commons/execution.py
@@ -99,11 +99,13 @@ def dispatch(data: Union[Resource, List[Resource]], fun_many: Callable,
 
 
 def catch_http_error(
-        r: requests.Response, error_to_throw: Type[BaseException], error_message_formatter
+        r: requests.Response, error_to_throw: Type[BaseException],
+        error_message_formatter: Callable,
+        to_catch: Type[BaseException]
 ):
     try:
         r.raise_for_status()
-    except requests.HTTPError as e:
+    except to_catch as e:
         raise error_to_throw(error_message_formatter(e)) from e
 
 

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -606,11 +606,11 @@ class KnowledgeGraphForge:
     @catch
     def retrieve(
         self,
-        id: str,
-        version: Optional[Union[int, str]] = None,
+        id: Union[str, List[str]],
+        version: Optional[Union[int, str, List[Union[str, int]]]] = None,
         cross_bucket: bool = False,
         **params
-    ) -> Resource:
+    ) -> Union[Optional[Resource], List[Optional[Resource]]]:
         """
         Retrieve a resource by its identifier from the configured store and possibly at a given version.
 


### PR DESCRIPTION
1. Generic catching of http errors on requests now also catches the errors thrown by aiohttp

2. In the case of retrieval, there is more logic that goes into making requests (there may be a single request, just like there may be 3 of them)
- Therefore, a different task_creator is used (can be found in BlueBrainNexus)

- The entire logic of retrieval is located inside a co-routine (async-await block), see _retrieve.
- In the case of single resource retrieval, we force a blocking call.
- In the case of multiple resources retrieval, a different task_creator is provided to BatchRequest.batch_request, one that schedules tasks that are based on the asynchronous retrieval logic.

When multiple ids are provided, if some fail but not all, for the failed ones an Action object is returned, and a Resource for the successful ones