### PR TITLE
Fixed coupled of issues

### DIFF
--- a/kgforge/core/archetypes/model.py
+++ b/kgforge/core/archetypes/model.py
@@ -55,16 +55,17 @@ class Model(ABC):
         prefixes = dict(sorted(self._prefixes().items(), key=lambda item: item[0]))
         if pretty:
             print("Used prefixes:")
-            df = DataFrame(prefixes)
-            formatters = {x: f"{{:<{df[x].str.len().max()}s}}".format for x in df.columns}
+            df = DataFrame(prefixes, index=[0])
+            formatters = {
+                x: f"{{:<{df[x].str.len().max()}s}}".format for x in df.columns
+            }
             print(df.to_string(header=False, index=False, formatters=formatters))
             return None
 
         return dict(prefixes)
 
     @abstractmethod
-    def _prefixes(self) -> Dict[str, str]:
-        ...
+    def _prefixes(self) -> Dict[str, str]: ...
 
     def types(self, pretty: bool) -> Optional[List[str]]:
         types = sorted(self._types())
@@ -131,10 +132,14 @@ class Model(ABC):
         ...
 
     def mappings(self, source: str, pretty: bool) -> Optional[Dict[str, List[str]]]:
-        mappings = {k: sorted(v) for k, v in
-                    sorted(self._mappings(source).items(), key=lambda kv: kv[0])}
+        mappings = {
+            k: sorted(v)
+            for k, v in sorted(self._mappings(source).items(), key=lambda kv: kv[0])
+        }
         if pretty:
-            print("Managed mappings for the data source per entity type and mapping type:")
+            print(
+                "Managed mappings for the data source per entity type and mapping type:"
+            )
             for k, v in mappings.items():
                 print(*[f"   - {k}:", *v], sep="\n        * ")
             return None
@@ -162,11 +167,22 @@ class Model(ABC):
         # POLICY Should retrieve the schema id of the given type.
         ...
 
-    def validate(self, data: Union[Resource, List[Resource]],
-                 execute_actions_before: bool, type_: str) -> None:
+    def validate(
+        self,
+        data: Union[Resource, List[Resource]],
+        execute_actions_before: bool,
+        type_: str,
+    ) -> None:
         # Replace None by self._validate_many to switch to optimized bulk validation.
-        run(self._validate_one, None, data, execute_actions=execute_actions_before,
-            exception=ValidationError, monitored_status="_validated", type_=type_)
+        run(
+            self._validate_one,
+            None,
+            data,
+            execute_actions=execute_actions_before,
+            exception=ValidationError,
+            monitored_status="_validated",
+            type_=type_,
+        )
 
     @abstractmethod
     def _validate_many(self, resources: List[Resource], type_: str) -> None:
@@ -201,17 +217,14 @@ class Model(ABC):
 
     @staticmethod
     @abstractmethod
-    def _service_from_directory(dirpath: Path, context_iri: Optional[str]) -> Any:
-        ...
+    def _service_from_directory(dirpath: Path, context_iri: Optional[str]) -> Any: ...
 
     @staticmethod
     @abstractmethod
-    def _service_from_url(url: str, context_iri: Optional[str]) -> Any:
-        ...
+    def _service_from_url(url: str, context_iri: Optional[str]) -> Any: ...
 
     @staticmethod
     @abstractmethod
     def _service_from_store(
-            store: 'Store', context_config: Optional[dict], **source_config
-    ) -> Any:
-        ...
+        store: "Store", context_config: Optional[dict], **source_config
+    ) -> Any: ...

--- a/kgforge/specializations/models/rdf/directory_service.py
+++ b/kgforge/specializations/models/rdf/directory_service.py
@@ -94,6 +94,8 @@ class DirectoryService(RdfService):
 
 
 def _load_rdf_files_as_graph(path: Path) -> RDFDataset:
+    if not path.exists():
+        raise ValueError(f"The path {path} does not exist")
     schema_graphs = RDFDataset()
     extensions = [".ttl", ".n3", ".json", ".rdf"]
     for f in path.rglob(os.path.join("*.*")):

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -74,7 +74,7 @@ class RdfModel(Model):
 
     def _types(self) -> List[str]:
         return [
-            self.service.context.to_symbol(cls)
+            self.service.context.to_symbol(str(cls))
             for cls in self.service.class_to_shape.keys()
         ]
 
@@ -95,7 +95,6 @@ class RdfModel(Model):
         try:
             shape_iri = self.service.get_shape_uriref_from_class_fragment(type)
             node_properties = self.service.materialize(shape_iri)
-            print(node_properties)
             dictionary = parse_attributes(node_properties, only_required, None)
             return dictionary
         except Exception as exc:

--- a/tests/specializations/models/test_rdf_directory_service.py
+++ b/tests/specializations/models/test_rdf_directory_service.py
@@ -13,6 +13,7 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 import os
 from pathlib import Path
+import pytest
 import rdflib
 from kgforge.specializations.models import RdfModel
 from kgforge.specializations.models.rdf.directory_service import (
@@ -37,6 +38,11 @@ def test_load_rdf_files_as_graph(shacl_schemas_file_path):
         expected_g = rdflib.Graph().parse(file_path, format="json-ld")
         assert len(g) > 0
         assert len(g) == len(expected_g)
+
+
+def test_load_not_existing_rdf_files_raise_error():
+    with pytest.raises(ValueError):
+        _load_rdf_files_as_graph(Path("not_existing_shacl_schemas_file_path"))
 
 
 def test_build_shapes_map(rdf_model_from_dir: RdfModel):


### PR DESCRIPTION
* forge.prefixes() was raising pandas.Dataframe error "if using all scalar values, you must pass an index"
* fixed forge.types() to properly collect types from rdfsercice.class_to_shape
* fixed forge.template() when using an rdf  model based on a store service: Unable to generate template:'tuple' object has no attribute 'traverse'