### PR TITLE
Add alternateName to agent resolver

### DIFF
--- a/examples/configurations/nexus-resolver/agent-to-resource-mapping.hjson
+++ b/examples/configurations/nexus-resolver/agent-to-resource-mapping.hjson
@@ -4,4 +4,5 @@
     name: x.name
     familyName: x.familyName
     givenName: x.givenName
+    alternateName: x.alternateName if hasattr(x, "alternateName") else None
 }

--- a/kgforge/specializations/resolvers/agent_resolver.py
+++ b/kgforge/specializations/resolvers/agent_resolver.py
@@ -43,13 +43,14 @@ class AgentResolver(Resolver):
         if target and target not in self.service.sources:
             raise ValueError(f"Unknown target value: {target}. Supported targets for the selected resolvers are: {self.service.sources.keys()}")
 
-        properties_to_filter_with = ['name', 'givenName', 'familyName']
+        properties_to_filter_with = ['name', 'givenName', 'familyName', 'alternateName']
         query_template = """
             CONSTRUCT {{
                 ?id a ?type ;
                 name ?name ;
                 givenName ?givenName ;
-                familyName ?familyName
+                familyName ?familyName ;
+                alternateName ?alternateName .
             }} WHERE {{
               GRAPH ?g {{
                 ?id a ?type .
@@ -62,12 +63,16 @@ class AgentResolver(Resolver):
                 OPTIONAL {{
                   ?id familyName ?familyName .
                 }}
+                OPTIONAL {{
+                  ?id alternateName ?alternateName .
+                }}
                 {{
                   SELECT * WHERE {{
                     {{ {0} ; name ?name {1} }} UNION
                     {{ {0} ; familyName ?familyName; givenName ?givenName {2} }} UNION
-                    {{ {0} ; familyName ?familyName; givenName ?givenName {3} }}
-                  }} LIMIT {4}
+                    {{ {0} ; familyName ?familyName; givenName ?givenName {3} }} UNION
+                    {{ {0} ; alternateName ?alternateName {4} }}
+                  }} LIMIT {5}
                 }}
               }}
             }}

--- a/tests/specializations/models/test_rdf_service.py
+++ b/tests/specializations/models/test_rdf_service.py
@@ -58,7 +58,7 @@ def test_get_shape_graph(rdf_model_from_dir: RdfModel):
             for sh_property in imported_sh_properties:
                 assert (URIRef(s["shape"]), SH.property, sh_property) in schema_graph
         if s["imports"]["ontology"] or s["indirect_imports"]["ontology"]:
-            assert len(ont_graph) == 34872
+            assert len(ont_graph) == 34874
         else:
             assert len(ont_graph) == 0
 

--- a/tests/specializations/models/test_rdf_service.py
+++ b/tests/specializations/models/test_rdf_service.py
@@ -58,7 +58,7 @@ def test_get_shape_graph(rdf_model_from_dir: RdfModel):
             for sh_property in imported_sh_properties:
                 assert (URIRef(s["shape"]), SH.property, sh_property) in schema_graph
         if s["imports"]["ontology"] or s["indirect_imports"]["ontology"]:
-            assert len(ont_graph) == 34874
+            assert len(ont_graph) == 34872
         else:
             assert len(ont_graph) == 0
 

--- a/tests/specializations/resolvers/test_resolver.py
+++ b/tests/specializations/resolvers/test_resolver.py
@@ -129,7 +129,8 @@ from kgforge.core.commons.strategies import ResolvingStrategy
                 ?id a ?type ;
                 name ?name ;
                 givenName ?givenName ;
-                familyName ?familyName
+                familyName ?familyName ;
+                alternateName ?alternateName .
             }} WHERE {{
               ?id a ?type . 
               OPTIONAL {{
@@ -141,23 +142,28 @@ from kgforge.core.commons.strategies import ResolvingStrategy
               OPTIONAL {{
                 ?id familyName ?familyName .
               }}
+              OPTIONAL {{
+                ?id alternateName ?alternateName .
+              }}
               {{
                 SELECT * WHERE {{
                   {{ {0} ; name ?name {1} }} UNION
                   {{ {0} ; familyName ?familyName; givenName ?givenName {2} }} UNION
-                  {{ {0} ; familyName ?familyName; givenName ?givenName {3} }}
-                }} LIMIT {4}
+                  {{ {0} ; familyName ?familyName; givenName ?givenName {3} }} UNION
+                  {{ {0} ; alternateName ?alternateName {4} }}
+                }} LIMIT {5}
               }}
             }}
             """),
-            (['name', 'givenName', 'familyName']),
+            (['name', 'givenName', 'familyName', 'alternateName']),
             ("EPFL"),
                 ("""
             CONSTRUCT {
                 ?id a ?type ;
                 name ?name ;
                 givenName ?givenName ;
-                familyName ?familyName
+                familyName ?familyName ;
+                alternateName ?alternateName .
             } WHERE {
               ?id a ?type . 
               OPTIONAL {
@@ -169,6 +175,9 @@ from kgforge.core.commons.strategies import ResolvingStrategy
               OPTIONAL {
                 ?id familyName ?familyName .
               }
+              OPTIONAL {
+                ?id alternateName ?alternateName .
+              }
               {
                 SELECT * WHERE {
                   { ?id <https://bluebrain.github.io/nexus/vocabulary/deprecated> "false"^^xsd:boolean ; a Class ; 
@@ -179,7 +188,10 @@ from kgforge.core.commons.strategies import ResolvingStrategy
  FILTER(?v0 = "value_1") ; familyName ?familyName; givenName ?givenName  FILTER (?givenName = "EPFL") } UNION
                   { ?id <https://bluebrain.github.io/nexus/vocabulary/deprecated> "false"^^xsd:boolean ; a Class ; 
  path_1 ?v0 . 
- FILTER(?v0 = "value_1") ; familyName ?familyName; givenName ?givenName  FILTER (?familyName = "EPFL") }
+ FILTER(?v0 = "value_1") ; familyName ?familyName; givenName ?givenName  FILTER (?familyName = "EPFL") } UNION
+                  { ?id <https://bluebrain.github.io/nexus/vocabulary/deprecated> "false"^^xsd:boolean ; a Class ; 
+ path_1 ?v0 . 
+ FILTER(?v0 = "value_1") ; alternateName ?alternateName  FILTER (?alternateName = "EPFL") }
                 } LIMIT 1
               }
             }


### PR DESCRIPTION
This will be useful for `Organization` and `Person`  to have an  `alternateName` (aka `alias`), such as acronym, or a version of the full name without accents.
NOTE: `alternateName` is a valid property listed in schema.org, and it exists already inside the nexus json-ld context