### PR TITLE
Add method when initializing forge to export pyshacl environment variable

### DIFF
--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -15,6 +15,7 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Type
 
+import os
 import numpy as np
 from pandas import DataFrame
 from rdflib import Graph
@@ -197,6 +198,8 @@ class KnowledgeGraphForge:
         :param kwargs:  keyword arguments
         """
 
+        self.set_environment_variables()
+
         if isinstance(configuration, str):
             config = load_yaml_from_file(configuration)
         else:
@@ -252,6 +255,11 @@ class KnowledgeGraphForge:
 
         # Formatters.
         self._formatters: Optional[Dict[str, str]] = config.pop("Formatters", None)
+
+    @staticmethod
+    def set_environment_variables():
+        # Set environment variable for pyshacl
+        os.system("export PYSHACL_USE_FULL_MIXIN=True")
 
     @catch
     def prefixes(self, pretty: bool = True) -> Optional[Dict[str, str]]:

--- a/kgforge/core/forge.py
+++ b/kgforge/core/forge.py
@@ -259,7 +259,7 @@ class KnowledgeGraphForge:
     @staticmethod
     def set_environment_variables():
         # Set environment variable for pyshacl
-        os.system("export PYSHACL_USE_FULL_MIXIN=True")
+        os.environ["PYSHACL_USE_FULL_MIXIN"] = "True"
 
     @catch
     def prefixes(self, pretty: bool = True) -> Optional[Dict[str, str]]:

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ from setuptools import find_packages, setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-# Set environment variable for pyshacl
-os.system("export PYSHACL_USE_FULL_MIXIN=True")
-
 # Get the long description from the README file.
 with open(os.path.join(HERE, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ from setuptools import find_packages, setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
+# Set environment variable for pyshacl
+os.system("export PYSHACL_USE_FULL_MIXIN=True")
+
 # Get the long description from the README file.
 with open(os.path.join(HERE, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()

--- a/tests/core/test_forge.py
+++ b/tests/core/test_forge.py
@@ -14,7 +14,7 @@
 
 # Test suite for initializing a forge.
 
-import pytest
+import os
 
 from kgforge.core.forge import KnowledgeGraphForge
 
@@ -28,6 +28,7 @@ class TestForgeInitialization:
 
     def test_initialization(self, config):
         forge = KnowledgeGraphForge(config)
+        assert os.environ['PYSHACL_USE_FULL_MIXIN'] == "True"
         assert type(forge._model).__name__ == MODEL
         assert type(forge._store).__name__ == STORE
         assert type(forge._resolvers[SCOPE][RESOLVER]).__name__ == RESOLVER


### PR DESCRIPTION
To ensure the pyshacl environment variable is set when using `forge.validate`, I added a method to set it at initializing a `KnowledgeGraphForge` instance.