### PR TITLE
Fix org and project metadata

### DIFF
--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -590,7 +590,8 @@ class BlueBrainNexus(Store):
     ) -> Tuple[str, str]:
         if cross_bucket:
             if store_metadata is not None:
-                org, project = store_metadata._project.split("/")
+                project = store_metadata._project.split("/")[-1]
+                org = store_metadata._project.split("/")[-2]
             else:
                 raise ValueError(
                     f"Downloading non registered file is not allowed when cross_bucket is set to True"


### PR DESCRIPTION
This accounts also for the case where the path that was given contains the "full bucket path", with endpoint and so on.
Now it takes only the last values, as it was doing before the latest change.