### PR TITLE
Parallelize validate

### DIFF
--- a/kgforge/core/archetypes/model.py
+++ b/kgforge/core/archetypes/model.py
@@ -177,7 +177,7 @@ class Model(ABC):
         # Replace None by self._validate_many to switch to optimized bulk validation.
         run(
             self._validate_one,
-            None,
+            self._validate_many,
             data,
             execute_actions=execute_actions_before,
             exception=ValidationError,

--- a/kgforge/specializations/models/demo_model.py
+++ b/kgforge/specializations/models/demo_model.py
@@ -127,7 +127,9 @@ class DemoModel(Model):
     def _validate_many(
         self, resources: List[Resource], type_: str, inference: str
     ) -> None:
-        raise not_supported()
+
+        for resource in resources:
+            self._validate_one(resource, type_, inference)
 
 
 class ModelLibrary:

--- a/kgforge/specializations/models/demo_model.py
+++ b/kgforge/specializations/models/demo_model.py
@@ -99,6 +99,8 @@ class DemoModel(Model):
         if reason is not None:
             raise ValidationError(reason)
 
+    _validate_many = None
+
     # Utils.
 
     @staticmethod
@@ -123,13 +125,6 @@ class DemoModel(Model):
 
     def schema_id(self, type: str) -> str:
         raise not_supported()
-
-    def _validate_many(
-        self, resources: List[Resource], type_: str, inference: str
-    ) -> None:
-
-        for resource in resources:
-            self._validate_one(resource, type_, inference)
 
 
 class ModelLibrary:

--- a/kgforge/specializations/models/rdf/service.py
+++ b/kgforge/specializations/models/rdf/service.py
@@ -140,6 +140,17 @@ class ShapesGraphWrapper(ShapesGraph):
 
         return ShapeWrapper(shape)
 
+    @property
+    def shapes(self):  # pyshacl implementation returns dict_values (not list). This cannot be pickled.
+        """
+
+        :returns: [Shape]
+        :rtype: list(pyshacl.shape.Shape)
+        """
+        if len(self._node_shape_cache) < 1:
+            self._build_node_shape_cache()
+        return list(self._node_shape_cache.values())
+
 
 class RdfService:
 

--- a/kgforge/specializations/models/rdf/store_service.py
+++ b/kgforge/specializations/models/rdf/store_service.py
@@ -70,7 +70,7 @@ class StoreService(RdfService):
     def generate_context(self) -> Dict:
         for shape_uriref, schema_uriref in self.shape_to_defining_resource.items():
             if schema_uriref not in self._imported:
-                self._transitive_load_shape_graph(
+                self._transitive_load_resource_graph(
                     self._get_named_graph_from_shape(shape_uriref), schema_uriref
                 )
         # reloads the shapes graph

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -160,7 +160,7 @@ class RdfModel(Model):
 
         return resource
 
-    def _get_shape_stuff(self, r: Resource, type_: str) -> Tuple[str, ShapeWrapper, Graph, Graph, Resource]:
+    def _prepare_shapes(self, r: Resource, type_: str) -> Tuple[str, ShapeWrapper, Graph, Graph, Resource]:
         type_to_validate = RdfService.type_to_validate_against(r, type_)
         shape, shacl_graph, ont_graph = self.service.get_shape_graph(
             node_shape_uriref=self.service.get_shape_uriref_from_class_fragment(type_to_validate)
@@ -179,7 +179,7 @@ class RdfModel(Model):
 
         def validate_iterator():
             for r in resources:
-                type_to_validate, shape, shacl_graph, ont_graph, r = self._get_shape_stuff(r, type_)
+                type_to_validate, shape, shacl_graph, ont_graph, r = self._prepare_shapes(r, type_)
                 yield type_to_validate, shape, shacl_graph, ont_graph, r, inference, self.service.context
 
         resources_2 = Pool(processes=VALIDATION_PARALLELISM).starmap(RdfModel.fc_call, validate_iterator())
@@ -190,7 +190,7 @@ class RdfModel(Model):
 
     def _validate_one(self, resource: Resource, type_: str, inference: str) -> None:
 
-        type_to_validate, shape, shacl_graph, ont_graph, r = self._get_shape_stuff(resource, type_)
+        type_to_validate, shape, shacl_graph, ont_graph, r = self._prepare_shapes(resource, type_)
 
         RdfModel._validate(
             resource=r, type_to_validate=type_to_validate, inference=inference, shape=shape, shacl_graph=shacl_graph,

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -13,7 +13,7 @@
 # along with Blue Brain Nexus Forge. If not, see <https://choosealicense.com/licenses/lgpl-3.0/>.
 import datetime
 import re
-from multiprocessing.pool import ThreadPool
+from multiprocessing import Pool
 from pathlib import Path
 from typing import Dict, List, Callable, Optional, Any, Union, Tuple
 
@@ -175,7 +175,7 @@ class RdfModel(Model):
                 resource=r, type_to_validate=type_to_validate, inference=inference, shape=shape, shacl_graph=shacl_graph, ont_graph=ont_graph, short_message=True, raise_=False
             )
 
-        ThreadPool(processes=VALIDATION_PARALLELISM).map(fc_call, t)
+        Pool(processes=VALIDATION_PARALLELISM).map(fc_call, t)
 
     def _validate_one(self, resource: Resource, type_: str, inference: str) -> None:
 

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -64,7 +64,7 @@ DEFAULT_VALUE = {
 
 DEFAULT_TYPE_ORDER = [str, float, int, bool, datetime.date, datetime.time]
 
-VALIDATION_PARALLELISM = 100
+VALIDATION_PARALLELISM = None
 
 
 class RdfModel(Model):
@@ -168,8 +168,7 @@ class RdfModel(Model):
         return type_to_validate, shape, shacl_graph, ont_graph, r
 
     @staticmethod
-    def fc_call(t):
-        type_to_validate, shape, shacl_graph, ont_graph, r, inference, context = t
+    def fc_call(type_to_validate, shape, shacl_graph, ont_graph, r, inference, context):
 
         return RdfModel._validate(
             resource=r, type_to_validate=type_to_validate, inference=inference, shape=shape, shacl_graph=shacl_graph,
@@ -183,7 +182,7 @@ class RdfModel(Model):
                 type_to_validate, shape, shacl_graph, ont_graph, r = self._get_shape_stuff(r, type_)
                 yield type_to_validate, shape, shacl_graph, ont_graph, r, inference, self.service.context
 
-        resources_2 = Pool().map(RdfModel.fc_call, validate_iterator())
+        resources_2 = Pool(processes=VALIDATION_PARALLELISM).starmap(RdfModel.fc_call, validate_iterator())
 
         for r_1, r_2 in zip(resources, resources_2):
             r_1._validated = r_2._validated

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -166,7 +166,7 @@ class RdfModel(Model):
 
     def _validate_many(self, resources: List[Resource], type_: str, inference: str) -> None:
 
-        t = [self._get_shape_stuff(r, type_) for r in resources] # Cannot be parallelized because loading the same shape at the same time leads to errors
+        t = [self._get_shape_stuff(r, type_) for r in resources]  # Cannot be parallelized because loading the same shape at the same time leads to errors
 
         def fc_call(arg):
             type_to_validate, shape, shacl_graph, ont_graph, r = arg


### PR DESCRIPTION
- the traverse function being optionally overwritten on Shape was due to a change in pyshacl versions (I believe an old version had this version but a newer one no longer had it. For the version we have fixed, this function does not exist) https://github.com/BlueBrain/nexus-forge/issues/43 https://github.com/BlueBrain/nexus-forge/pull/44 
- renamed usage of `_transitive_load_shape_graph` to `_transitive_load_resource_graph`
- dummy implementation of `_validate_many` in `DemoModel`
- Override pyshacl `ShapesGraph` implementation of `def shapes` to return `list` instead of `dict_values()` so that it can be picklable (for multiprocessing)
- Parallelized validate. 
  -> cannot use threads because pyshacl uses rdflib, rdflib uses pyparsing and it is not thread safe
  -> shape loading occurs before creating multiple processes for validation. It would be possible to load shapes in individual processes, however: 
       - "caching" of shapes becomes useless, the same shape will be queried multiple times across processes 
       - Shape loading in individual processes would be best if validating resources of different types/shapes
       - The former point might not be completely true because shapes re-use each other
       - It is for sure better to load the shapes beforehand if we're dealing with a list of resources of the same type/shape.
    Given these reasons, I opted for loading all shapes beforehand.
