### PR TITLE
Simplify retrieve

### DIFF
--- a/kgforge/specializations/models/rdf/store_service.py
+++ b/kgforge/specializations/models/rdf/store_service.py
@@ -163,9 +163,7 @@ class StoreService(RdfService):
 
     def load_resource_graph_from_source(self, graph_id: str, schema_id: str) -> Graph:
         try:
-            schema_resource = self.context_store.retrieve(
-                schema_id, version=None, cross_bucket=False
-            )
+            schema_resource = self.context_store.retrieve_schema(schema_id)
         except RetrievalError as e:
             raise ValueError(f"Failed to retrieve {schema_id}: {str(e)}") from e
         json_dict = as_jsonld(

--- a/kgforge/specializations/models/rdf/store_service.py
+++ b/kgforge/specializations/models/rdf/store_service.py
@@ -163,13 +163,11 @@ class StoreService(RdfService):
 
     def load_resource_graph_from_source(self, graph_id: str, schema_id: str) -> Graph:
         try:
-            schema_resource = self.context_store.retrieve_schema(schema_id)
+            schema_resource = self.context_store.retrieve(
+                schema_id, version=None, cross_bucket=False
+            )
         except RetrievalError as e:
-            try:
-                schema_resource = self.context_store.retrieve(schema_id, cross_bucket=False, version=None)
-            except RetrievalError as e2:
-                raise ValueError(f"Failed to retrieve {schema_id}: {str(e2)}") from e2
-
+            raise ValueError(f"Failed to retrieve {schema_id}: {str(e)}") from e
         json_dict = as_jsonld(
             schema_resource,
             form="expanded",

--- a/kgforge/specializations/models/rdf/store_service.py
+++ b/kgforge/specializations/models/rdf/store_service.py
@@ -165,7 +165,11 @@ class StoreService(RdfService):
         try:
             schema_resource = self.context_store.retrieve_schema(schema_id)
         except RetrievalError as e:
-            raise ValueError(f"Failed to retrieve {schema_id}: {str(e)}") from e
+            try:
+                schema_resource = self.context_store.retrieve(schema_id, cross_bucket=False, version=None)
+            except RetrievalError as e2:
+                raise ValueError(f"Failed to retrieve {schema_id}: {str(e2)}") from e2
+
         json_dict = as_jsonld(
             schema_resource,
             form="expanded",

--- a/kgforge/specializations/models/rdf_model.py
+++ b/kgforge/specializations/models/rdf_model.py
@@ -64,7 +64,7 @@ DEFAULT_VALUE = {
 
 DEFAULT_TYPE_ORDER = [str, float, int, bool, datetime.date, datetime.time]
 
-VALIDATION_PARALLELISM = None
+VALIDATION_PARALLELISM = 10
 
 
 class RdfModel(Model):

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -296,7 +296,7 @@ class BlueBrainNexus(Store):
             raise RetrievalError(e) from e
 
     async def _get_resource_async(
-        self, session, url: str, query_params: Dict
+        self, session: ClientSession, url: str, query_params: Dict
     ) -> Resource:
 
         async with session.request(

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -281,7 +281,7 @@ class BlueBrainNexus(Store):
         )
 
         catch_http_error_nexus(
-            response, RetrievalError, aiohttp_error=True
+            response, RetrievalError, aiohttp_error=False
         )
 
         response_json = response.json()

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -431,35 +431,6 @@ class BlueBrainNexus(Store):
         )
         return batch_results
 
-    def retrieve_schema(self, id_: bool) -> Resource:
-
-        url = self.service.add_resource_id_to_endpoint(endpoint=self.service.url_schemas, resource_id=id_)
-
-        response_not_source_with_metadata = requests.request(method=hdrs.METH_GET, url=url, headers=self.service.headers)
-
-        not_source_with_metadata = response_not_source_with_metadata.json()
-
-        catch_http_error_nexus(response_not_source_with_metadata, RetrievalError)
-
-        _self = not_source_with_metadata.get("_self", None)
-
-        if not _self:
-            raise RetrievalError("Cannot find metadata in payload")
-
-        response_source = requests.request(method=hdrs.METH_GET, url=f"{_self}/source", headers=self.service.headers)
-
-        data_source = response_source.json()
-
-        catch_http_error_nexus(response_source, RetrievalError)
-
-        # turns the retrieved data into a resource
-        resource = self.service.to_resource(data_source)
-
-        # uses the metadata of the first call
-        self.service.synchronize_resource(resource, not_source_with_metadata, self.retrieve_schema.__name__, True, True)
-
-        return resource
-
     def retrieve(
         self,
         id_: Union[str, List[str]],

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -428,6 +428,35 @@ class BlueBrainNexus(Store):
         )
         return batch_results
 
+    def retrieve_schema(self, id_: bool) -> Resource:
+
+        url = self.service.add_resource_id_to_endpoint(endpoint=self.service.url_schemas, resource_id=id_)
+
+        response_not_source_with_metadata = requests.request(method=hdrs.METH_GET, url=url, headers=self.service.headers)
+
+        not_source_with_metadata = response_not_source_with_metadata.json()
+
+        catch_http_error_nexus(response_not_source_with_metadata, RetrievalError)
+
+        _self = not_source_with_metadata.get("_self", None)
+
+        if not _self:
+            raise RetrievalError("Cannot find metadata in payload")
+
+        response_source = requests.request(method=hdrs.METH_GET, url=f"{_self}/source", headers=self.service.headers)
+
+        data_source = response_source.json()
+
+        catch_http_error_nexus(response_source, RetrievalError)
+
+        # turns the retrieved data into a resource
+        resource = self.service.to_resource(data_source)
+
+        # uses the metadata of the first call
+        self.service.synchronize_resource(resource, not_source_with_metadata, self.retrieve_schema.__name__, True, True)
+
+        return resource
+
     def retrieve(
         self,
         id_: Union[str, List[str]],
@@ -489,6 +518,8 @@ class BlueBrainNexus(Store):
         )
 
         retrieve_source = params.get("retrieve_source", True)
+
+        # add_resource_id_to_endpoint
 
         if retrieve_source:
             query_params.update({"annotate": "true"})

--- a/kgforge/specializations/stores/nexus/batch_request_handler.py
+++ b/kgforge/specializations/stores/nexus/batch_request_handler.py
@@ -28,9 +28,9 @@ class BatchRequestHandler:
     @staticmethod
     def batch(iterable, n=BATCH_SIZE):
 
-        l = len(iterable)
-        for ndx in range(0, l, n):
-            yield iterable[ndx:min(ndx + n, l)]
+        length_v = len(iterable)
+        for ndx in range(0, length_v, n):
+            yield iterable[ndx:min(ndx + n, length_v)]
 
     @staticmethod
     def batch_request(
@@ -150,4 +150,3 @@ class BatchRequestHandler:
                 tasks.append(prepared_request)
 
         return tasks, sessions
-

--- a/kgforge/specializations/stores/nexus/batch_request_handler.py
+++ b/kgforge/specializations/stores/nexus/batch_request_handler.py
@@ -6,6 +6,8 @@ import asyncio
 from typing import Callable, Dict, List, Optional, Tuple, Type, Any
 
 from kgforge.core.commons.constants import DEFAULT_REQUEST_TIMEOUT
+
+import aiohttp
 from typing_extensions import Unpack
 
 from aiohttp import ClientSession, ClientTimeout

--- a/kgforge/specializations/stores/nexus/batch_request_handler.py
+++ b/kgforge/specializations/stores/nexus/batch_request_handler.py
@@ -2,14 +2,11 @@ from asyncio import AbstractEventLoop
 from collections import namedtuple
 import json
 import asyncio
-import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor
 
 from typing import Callable, Dict, List, Optional, Tuple, Type, Any, Coroutine
 
 from kgforge.core.commons.constants import DEFAULT_REQUEST_TIMEOUT
 
-import aiohttp
 from typing_extensions import Unpack
 
 from aiohttp import ClientSession, ClientTimeout
@@ -139,15 +136,13 @@ class BatchRequestHandler:
             sessions.append(session)
 
             for res in batch_i:
-                # result = fc(res, client_session=session)
-                # prepared_request: asyncio.Task = loop.create_task(result)
+                result = fc(res, client_session=session)
+                prepared_request: asyncio.Task = loop.create_task(result)
 
-                with ThreadPoolExecutor() as executor:
-                    prepared_request: asyncio.Task = loop.run_in_executor(executor, fc, res, session)
-                    if callback:
-                        prepared_request.add_done_callback(callback)
+                if callback:
+                    prepared_request.add_done_callback(callback)
 
-                    tasks.append(prepared_request)
+                tasks.append(prepared_request)
 
         return tasks, sessions
 

--- a/kgforge/specializations/stores/nexus/batch_request_handler.py
+++ b/kgforge/specializations/stores/nexus/batch_request_handler.py
@@ -135,7 +135,7 @@ class BatchRequestHandler:
 
         for batch_i in BatchRequestHandler.batch(elements):
 
-            session = ClientSession()
+            session = ClientSession(timeout=ClientTimeout(BATCH_REQUEST_TIMEOUT_PER_REQUEST))
             sessions.append(session)
 
             for res in batch_i:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "pyparsing>=2.0.2",
         "owlrl>=5.2.3",
         "elasticsearch_dsl==7.4.0",
-        "requests==2.31.0",
+        "requests==2.32.0",
         "typing-extensions"
     ],
     extras_require={


### PR DESCRIPTION
- 2 (main+metadata through resource endpoint) or 3 (main fail through resource endpoint, main+metadata through resolver endpoint) requests were necessary to retrieve resources:
    - When using cross_bucket = False, the resource endpoint is used. There was an issue with the retrieval of the metadata with annotate = True. It has since then been fixed https://github.com/BlueBrain/nexus/issues/4737 
    - When using cross_bucket = True, the resolvers endpoint is used. It was not possible to get metadata along with the data if retrieve_source = True, now it is, with the annotate=True query parameter. https://github.com/BlueBrain/nexus/issues/4717

- Remove async force complete for retrieval of one resource. Synchronous requests are now used, since the body of the function is simpler, a little bit of duplication doesn't hurt as much.

- To avoid the client session staying open too long, leading to a ServerDisconnectedError. + all tasks/resources no longer share the same client session (a batch of tasks/resources per client session)

- When using the resource endpoint, the annotate query parameter only works for regular resources. It fails if we attempt to retrieve a schema with it. The best thing would be to use the schema endpoint with the annotate query parameter but that isn't supported by delta yet. So the mechanism to retrieve data (not source) + metadata, then data (source) without metadata, and then to merge them has been kept in a retrieve_schema method. 

- https://github.com/BlueBrain/nexus/pull/5079 RDFModel's validate uses the resource retrieve implementation to get schemas and ontologies. It was not possible to use the annotate query parameter in order to retrieve schemas through the resource endpoint until this change in the API. 