### PR TITLE
Use jsonpath to collect values when downloading a file

### DIFF
--- a/kgforge/core/archetypes/read_only_store.py
+++ b/kgforge/core/archetypes/read_only_store.py
@@ -26,7 +26,7 @@ from kgforge.core.commons.exceptions import (
 )
 from kgforge.core.commons.execution import not_supported
 from kgforge.core.commons.sparql_query_builder import SPARQLQueryBuilder
-from kgforge.core.reshaping import collect_values
+from kgforge.core.reshaping import collect_values, collect_values_jp
 from kgforge.core.wrappings import Filter
 from kgforge.core.wrappings.dict import DictWrapper
 
@@ -107,9 +107,13 @@ class ReadOnlyStore(ABC):
         # path: DirPath.
         urls = []
         store_metadata = []
+        constraint_dict = None
+        if content_type:
+            constraint_dict = {'encodingFormat': content_type}
         to_download = [data] if isinstance(data, Resource) else data
         for d in to_download:
-            collected_values = collect_values(d, follow, DownloadingError)
+            # collected_values = collect_values(d, follow, DownloadingError)
+            collected_values = collect_values_jp(d, follow, DownloadingError, constraint_dict)
             urls.extend(collected_values)
             store_metadata.extend(
                 [d._store_metadata for _ in range(len(collected_values))]

--- a/kgforge/core/reshaping.py
+++ b/kgforge/core/reshaping.py
@@ -114,10 +114,7 @@ def collect_values_jp(data: Resource, follow: str,
                       constraint_dict: Optional[Dict] = None) -> List[str]:
     try:
         properties = follow.split('.')
-        if len(properties) == 0:
-            pattern = f"$.{pattern}"
-        else:
-            pattern = f"$." + "[*].".join(properties)
+        pattern = f"$." + "[*].".join(properties)
         jp_query = jp.parse(pattern)
         data = as_json(data, False, False, None, None, None)
         results = jp_query.find(data)

--- a/kgforge/specializations/stores/bluebrain_nexus.py
+++ b/kgforge/specializations/stores/bluebrain_nexus.py
@@ -601,8 +601,6 @@ class BlueBrainNexus(Store):
         params_download = copy.deepcopy(self.service.params.get("download", {}))
         headers = (
             self.service.headers_download
-            if not content_type
-            else update_dict(self.service.headers_download, {"Accept": content_type})
         )
 
         response = requests.get(

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         "owlrl>=5.2.3",
         "elasticsearch_dsl==7.4.0",
         "requests==2.32.0",
-        "typing-extensions"
+        "typing-extensions",
+        "jsonpath-ng"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
There was a problem when doing something like:
```
forge.download(cell_types_ontology, path=my_path, content_type='application/ld+json')
```
when the encodingFormat was JSON,  as it was used in the headers, and the metadata of the file was return instead of the content of the file.

Solution:
Use the default headers (`Accept : */*`) to download the content of a file and switch to jsonpath to collect values from a given path.